### PR TITLE
Srcset support related

### DIFF
--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -7,28 +7,50 @@ import Button from './components/Button';
 import Gallery from './components/Gallery';
 
 const IMAGES = [
-	'http://www.fillmurray.com/400/600',
-	'http://www.fillmurray.com/600/900',
-	'http://www.fillmurray.com/500/500',
-	'http://www.fillmurray.com/700/700',
-	'http://www.fillmurray.com/900/600',
-	'http://www.fillmurray.com/600/400',
+	'https://c1.staticflickr.com/9/8383/8517694980_21bef8e9fc_c.jpg',
+	'https://c1.staticflickr.com/9/8379/8516580741_058e7c7317_c.jpg',
+	'https://c1.staticflickr.com/9/8509/8517695778_f08f11150f_c.jpg',
+	'https://c1.staticflickr.com/9/8109/8526026980_a152c5f11d_c.jpg',
+	'https://c1.staticflickr.com/9/8243/8524916085_ed79b45249_c.jpg',
+	'https://c2.staticflickr.com/8/7489/16129020136_f36604d33f_c.jpg',
 
-	'http://www.fillmurray.com/401/601',
-	'http://www.fillmurray.com/601/901',
-	'http://www.fillmurray.com/501/501',
-	'http://www.fillmurray.com/701/701',
-	'http://www.fillmurray.com/901/601',
-	'http://www.fillmurray.com/601/401',
+	'https://c1.staticflickr.com/9/8376/8526026438_a06baf0f58_c.jpg',
+	'https://c1.staticflickr.com/9/8225/8524911453_598b176b7e_c.jpg',
+	'https://c1.staticflickr.com/9/8513/8533369906_96f03a6434_c.jpg',
+	'https://c1.staticflickr.com/9/8096/8532223657_b1efa18ac8_c.jpg',
+	'https://c1.staticflickr.com/9/8390/8532222553_e0e05dbdd6_c.jpg',
+	'https://c1.staticflickr.com/9/8513/8533333694_736fc6c9af_c.jpg',
 
-	'http://www.fillmurray.com/402/602',
-	'http://www.fillmurray.com/602/902',
-	'http://www.fillmurray.com/502/502',
-	'http://www.fillmurray.com/702/702',
-	'http://www.fillmurray.com/902/602',
-	'http://www.fillmurray.com/602/402',
+	'https://c1.staticflickr.com/9/8391/8532223463_abe07ac0a6_c.jpg',
+	'https://c1.staticflickr.com/9/8365/8529344273_eedda51ea1_c.jpg',
+	'https://c1.staticflickr.com/9/8381/8527501230_61882a7918_c.jpg',
+	'https://c2.staticflickr.com/8/7538/15535067073_5835371a5f_c.jpg',
+	'https://c2.staticflickr.com/8/7550/15532469404_e39e2fe2e8_c.jpg',
+	'https://c2.staticflickr.com/8/7581/16129016486_085eb8dedd_c.jpg',
 ];
 
+const THUMBS = [
+	'https://c1.staticflickr.com/9/8383/8517694980_21bef8e9fc_s.jpg',
+        'https://c1.staticflickr.com/9/8379/8516580741_058e7c7317_s.jpg',
+        'https://c1.staticflickr.com/9/8509/8517695778_f08f11150f_s.jpg',
+        'https://c1.staticflickr.com/9/8109/8526026980_a152c5f11d_s.jpg',
+        'https://c1.staticflickr.com/9/8243/8524916085_ed79b45249_s.jpg',
+        'https://c2.staticflickr.com/8/7489/16129020136_f36604d33f_s.jpg',
+        
+        'https://c1.staticflickr.com/9/8376/8526026438_a06baf0f58_s.jpg',
+        'https://c1.staticflickr.com/9/8225/8524911453_598b176b7e_s.jpg',
+        'https://c1.staticflickr.com/9/8513/8533369906_96f03a6434_s.jpg',
+        'https://c1.staticflickr.com/9/8096/8532223657_b1efa18ac8_s.jpg',
+        'https://c1.staticflickr.com/9/8390/8532222553_e0e05dbdd6_s.jpg',
+        'https://c1.staticflickr.com/9/8513/8533333694_736fc6c9af_s.jpg',
+        
+        'https://c1.staticflickr.com/9/8391/8532223463_abe07ac0a6_s.jpg',
+        'https://c1.staticflickr.com/9/8365/8529344273_eedda51ea1_s.jpg',
+        'https://c1.staticflickr.com/9/8381/8527501230_61882a7918_s.jpg',
+        'https://c2.staticflickr.com/8/7538/15535067073_5835371a5f_s.jpg',
+        'https://c2.staticflickr.com/8/7550/15532469404_e39e2fe2e8_s.jpg',
+        'https://c2.staticflickr.com/8/7581/16129016486_085eb8dedd_s.jpg',
+]; 
 const styles = Lightbox.extendStyles({
 	image: {
 		border: '10px solid white',
@@ -45,12 +67,12 @@ const styles = Lightbox.extendStyles({
 render(
 	<div>
 		<p style={{ marginBottom: 40 }}>Use your keyboard to navigate <kbd>left</kbd> <kbd>right</kbd> <kbd>esc</kbd> &mdash; Also, try resizing your browser window.</p>
-		<Gallery heading="Gallery" images={IMAGES} />
-		<Gallery heading="Custom Styles" images={IMAGES} styles={styles} />
+		<Gallery heading="Gallery" images={IMAGES} thumbs={THUMBS} />
+		<Gallery heading="Custom Styles" images={IMAGES} thumbs={THUMBS} styles={styles} />
 		<Button heading="Launch with a button" images={IMAGES} />
 		<hr />
 		<p className="hint">
-			Images courtesy of <a href="http://www.fillmurray.com" target="_blank">http://www.fillmurray.com</a>
+			Images courtesy of <a href="http://www.sandygonzales.com" target="_blank">Sandy Gonzales</a>
 		</p>
 	</div>,
 	document.getElementById('example')

--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -29,7 +29,7 @@ const IMAGES = [
 	'https://c2.staticflickr.com/8/7581/16129016486_085eb8dedd_c.jpg',
 ];
 
-const THUMBS = [
+const THUMBNAILS = [
 	'https://c1.staticflickr.com/9/8383/8517694980_21bef8e9fc_s.jpg',
         'https://c1.staticflickr.com/9/8379/8516580741_058e7c7317_s.jpg',
         'https://c1.staticflickr.com/9/8509/8517695778_f08f11150f_s.jpg',
@@ -67,8 +67,8 @@ const styles = Lightbox.extendStyles({
 render(
 	<div>
 		<p style={{ marginBottom: 40 }}>Use your keyboard to navigate <kbd>left</kbd> <kbd>right</kbd> <kbd>esc</kbd> &mdash; Also, try resizing your browser window.</p>
-		<Gallery heading="Gallery" images={IMAGES} thumbs={THUMBS} />
-		<Gallery heading="Custom Styles" images={IMAGES} thumbs={THUMBS} styles={styles} />
+		<Gallery heading="Gallery" images={IMAGES} thumbnails={THUMBNAILS} />
+		<Gallery heading="Custom Styles" images={IMAGES} thumbnails={THUMBNAILS} styles={styles} />
 		<Button heading="Launch with a button" images={IMAGES} />
 		<hr />
 		<p className="hint">

--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -6,8 +6,6 @@ import Lightbox from 'react-images';
 import Button from './components/Button';
 import Gallery from './components/Gallery';
 
-
-
 const IMAGES = [
     {    
 	src: 'https://c1.staticflickr.com/9/8383/8517694980_21bef8e9fc_c.jpg',

--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -6,51 +6,176 @@ import Lightbox from 'react-images';
 import Button from './components/Button';
 import Gallery from './components/Gallery';
 
+
+
 const IMAGES = [
-	'https://c1.staticflickr.com/9/8383/8517694980_21bef8e9fc_c.jpg',
-	'https://c1.staticflickr.com/9/8379/8516580741_058e7c7317_c.jpg',
-	'https://c1.staticflickr.com/9/8509/8517695778_f08f11150f_c.jpg',
-	'https://c1.staticflickr.com/9/8109/8526026980_a152c5f11d_c.jpg',
-	'https://c1.staticflickr.com/9/8243/8524916085_ed79b45249_c.jpg',
-	'https://c2.staticflickr.com/8/7489/16129020136_f36604d33f_c.jpg',
+    {    
+	src: 'https://c1.staticflickr.com/9/8383/8517694980_21bef8e9fc_c.jpg',
+	thumbnail: 'https://c1.staticflickr.com/9/8383/8517694980_21bef8e9fc_s.jpg',
+	srcset: [
+		    'https://c1.staticflickr.com/9/8383/8517694980_21bef8e9fc_b.jpg 1024w',
+		    'https://c1.staticflickr.com/9/8383/8517694980_21bef8e9fc_c.jpg 800w',
+		    'https://c1.staticflickr.com/9/8383/8517694980_21bef8e9fc.jpg 500w',
+		    'https://c1.staticflickr.com/9/8383/8517694980_21bef8e9fc_n.jpg 320w'
+		],
+    },
+    { 
+	src: 'https://c1.staticflickr.com/9/8379/8516580741_058e7c7317_c.jpg',
+	thumbnail: 'https://c1.staticflickr.com/9/8379/8516580741_058e7c7317_s.jpg',
+	srcset: [
+		    'https://c1.staticflickr.com/9/8379/8516580741_058e7c7317_b.jpg 1024w',
+		    'https://c1.staticflickr.com/9/8379/8516580741_058e7c7317_c.jpg 800w',
+		    'https://c1.staticflickr.com/9/8379/8516580741_058e7c7317.jpg 500w',
+		    'https://c1.staticflickr.com/9/8379/8516580741_058e7c7317_n.jpg 320w'
+		]
+    },
+    {
+	src: 'https://c1.staticflickr.com/9/8509/8517695778_f08f11150f_c.jpg',
+	thumbnail: 'https://c1.staticflickr.com/9/8509/8517695778_f08f11150f_s.jpg',
+	srcset: [
+		    'https://c1.staticflickr.com/9/8509/8517695778_f08f11150f_b.jpg 1024w',
+		    'https://c1.staticflickr.com/9/8509/8517695778_f08f11150f_c.jpg 800w',
+		    'https://c1.staticflickr.com/9/8509/8517695778_f08f11150f.jpg 500w',
+		    'https://c1.staticflickr.com/9/8509/8517695778_f08f11150f_n.jpg 320w'
+		]
+    },
+    {
+	src: 'https://c1.staticflickr.com/9/8109/8526026980_a152c5f11d_z.jpg',
+	thumbnail: 'https://c1.staticflickr.com/9/8109/8526026980_a152c5f11d_s.jpg',
+    },
+    {
+	src: 'https://c1.staticflickr.com/9/8243/8524916085_ed79b45249_z.jpg',
+	thumbnail: 'https://c1.staticflickr.com/9/8243/8524916085_ed79b45249_s.jpg',
+    },
+    {
+	src: 'https://c2.staticflickr.com/8/7489/16129020136_f36604d33f_c.jpg',
+	thumbnail: 'https://c2.staticflickr.com/8/7489/16129020136_f36604d33f_s.jpg',
+	srcset: [
+		    'https://c2.staticflickr.com/8/7489/16129020136_f36604d33f_b.jpg 1024w',
+		    'https://c2.staticflickr.com/8/7489/16129020136_f36604d33f_c.jpg 800w',
+		    'https://c2.staticflickr.com/8/7489/16129020136_f36604d33f.jpg 500w',
+		    'https://c2.staticflickr.com/8/7489/16129020136_f36604d33f_n.jpg 320w'
+		]
+    },
 
-	'https://c1.staticflickr.com/9/8376/8526026438_a06baf0f58_c.jpg',
-	'https://c1.staticflickr.com/9/8225/8524911453_598b176b7e_c.jpg',
-	'https://c1.staticflickr.com/9/8513/8533369906_96f03a6434_c.jpg',
-	'https://c1.staticflickr.com/9/8096/8532223657_b1efa18ac8_c.jpg',
-	'https://c1.staticflickr.com/9/8390/8532222553_e0e05dbdd6_c.jpg',
-	'https://c1.staticflickr.com/9/8513/8533333694_736fc6c9af_c.jpg',
 
-	'https://c1.staticflickr.com/9/8391/8532223463_abe07ac0a6_c.jpg',
-	'https://c1.staticflickr.com/9/8365/8529344273_eedda51ea1_c.jpg',
-	'https://c1.staticflickr.com/9/8381/8527501230_61882a7918_c.jpg',
-	'https://c2.staticflickr.com/8/7538/15535067073_5835371a5f_c.jpg',
-	'https://c2.staticflickr.com/8/7550/15532469404_e39e2fe2e8_c.jpg',
-	'https://c2.staticflickr.com/8/7581/16129016486_085eb8dedd_c.jpg',
+    {
+	src: 'https://c1.staticflickr.com/9/8376/8526026438_a06baf0f58_c.jpg',
+	thumbnail: 'https://c1.staticflickr.com/9/8376/8526026438_a06baf0f58_s.jpg',
+	srcset: [
+		    'https://c1.staticflickr.com/9/8376/8526026438_a06baf0f58_b.jpg 1024w',
+		    'https://c1.staticflickr.com/9/8376/8526026438_a06baf0f58_c.jpg 800w',
+		    'https://c1.staticflickr.com/9/8376/8526026438_a06baf0f58.jpg 500w',
+		    'https://c1.staticflickr.com/9/8376/8526026438_a06baf0f58_n.jpg 320w'
+		]
+    },
+    {
+	src: 'https://c1.staticflickr.com/9/8225/8524911453_598b176b7e_c.jpg',
+	thumbnail: 'https://c1.staticflickr.com/9/8225/8524911453_598b176b7e_s.jpg',
+	srcset: [
+		    'https://c1.staticflickr.com/9/8225/8524911453_598b176b7e_b.jpg 1024w',
+		    'https://c1.staticflickr.com/9/8225/8524911453_598b176b7e_c.jpg 800w',
+		    'https://c1.staticflickr.com/9/8225/8524911453_598b176b7e.jpg 500w',
+		    'https://c1.staticflickr.com/9/8225/8524911453_598b176b7e_n.jpg 320w'
+		]
+    },
+    {
+	src: 'https://c1.staticflickr.com/9/8513/8533369906_96f03a6434_c.jpg',
+	thumbnail: 'https://c1.staticflickr.com/9/8513/8533369906_96f03a6434_s.jpg',
+	srcset: [
+		    'https://c1.staticflickr.com/9/8513/8533369906_96f03a6434_b.jpg 1024w',
+		    'https://c1.staticflickr.com/9/8513/8533369906_96f03a6434_c.jpg 800w',
+		    'https://c1.staticflickr.com/9/8513/8533369906_96f03a6434.jpg 500w',
+		    'https://c1.staticflickr.com/9/8513/8533369906_96f03a6434_n.jpg 320w'
+		]
+    },
+    {
+	src: 'https://c1.staticflickr.com/9/8096/8532223657_b1efa18ac8_c.jpg',
+	thumbnail: 'https://c1.staticflickr.com/9/8096/8532223657_b1efa18ac8_s.jpg',
+	srcset: [
+		    'https://c1.staticflickr.com/9/8096/8532223657_b1efa18ac8_b.jpg 1024w',
+		    'https://c1.staticflickr.com/9/8096/8532223657_b1efa18ac8_c.jpg 800w',
+		    'https://c1.staticflickr.com/9/8096/8532223657_b1efa18ac8.jpg 500w',
+		    'https://c1.staticflickr.com/9/8096/8532223657_b1efa18ac8_n.jpg 320w'
+		]
+    },
+    {
+	src: 'https://c1.staticflickr.com/9/8390/8532222553_e0e05dbdd6_c.jpg',
+	thumbnail: 'https://c1.staticflickr.com/9/8390/8532222553_e0e05dbdd6_s.jpg',
+	srcset: [
+		    'https://c1.staticflickr.com/9/8390/8532222553_e0e05dbdd6_b.jpg 1024w',
+		    'https://c1.staticflickr.com/9/8390/8532222553_e0e05dbdd6_c.jpg 800w',
+		    'https://c1.staticflickr.com/9/8390/8532222553_e0e05dbdd6.jpg 500w',
+		    'https://c1.staticflickr.com/9/8390/8532222553_e0e05dbdd6_n.jpg 320w'
+		]
+    },
+    {
+	src: 'https://c1.staticflickr.com/9/8513/8533333694_736fc6c9af_c.jpg',
+	thumbnail: 'https://c1.staticflickr.com/9/8513/8533333694_736fc6c9af_s.jpg',
+	srcset: [
+		    'https://c1.staticflickr.com/9/8513/8533333694_736fc6c9af_b.jpg 1024w',
+		    'https://c1.staticflickr.com/9/8513/8533333694_736fc6c9af_c.jpg 800w',
+		    'https://c1.staticflickr.com/9/8513/8533333694_736fc6c9af.jpg 500w',
+		    'https://c1.staticflickr.com/9/8513/8533333694_736fc6c9af_n.jpg 320w'
+		]
+    },
+
+
+    {
+	src: 'https://c1.staticflickr.com/9/8391/8532223463_abe07ac0a6_z.jpg',
+	thumbnail: 'https://c1.staticflickr.com/9/8391/8532223463_abe07ac0a6_s.jpg',
+    },
+    {
+	src: 'https://c1.staticflickr.com/9/8365/8529344273_eedda51ea1_c.jpg',
+	thumbnail: 'https://c1.staticflickr.com/9/8365/8529344273_eedda51ea1_s.jpg',
+	srcset: [
+		    'https://c1.staticflickr.com/9/8365/8529344273_eedda51ea1_b.jpg 1024w',
+		    'https://c1.staticflickr.com/9/8365/8529344273_eedda51ea1_c.jpg 800w',
+		    'https://c1.staticflickr.com/9/8365/8529344273_eedda51ea1.jpg 500w',
+		    'https://c1.staticflickr.com/9/8365/8529344273_eedda51ea1_n.jpg 320w'
+		]
+    },
+    {
+	src: 'https://c1.staticflickr.com/9/8381/8527501230_61882a7918_c.jpg',
+	thumbnail: 'https://c1.staticflickr.com/9/8381/8527501230_61882a7918_s.jpg',
+	srcset: [
+		    'https://c1.staticflickr.com/9/8381/8527501230_61882a7918_b.jpg 1024w',
+		    'https://c1.staticflickr.com/9/8381/8527501230_61882a7918_c.jpg 800w',
+		    'https://c1.staticflickr.com/9/8381/8527501230_61882a7918.jpg 500w',
+		    'https://c1.staticflickr.com/9/8381/8527501230_61882a7918_n.jpg 320w'
+		]
+    },
+    {
+	src: 'https://c2.staticflickr.com/8/7538/15535067073_5835371a5f_c.jpg',
+	thumbnail: 'https://c2.staticflickr.com/8/7538/15535067073_5835371a5f_s.jpg',
+	srcset: [
+		    'https://c2.staticflickr.com/8/7538/15535067073_5835371a5f_b.jpg 1024w',
+		    'https://c2.staticflickr.com/8/7538/15535067073_5835371a5f_c.jpg 800w',
+		    'https://c2.staticflickr.com/8/7538/15535067073_5835371a5f.jpg 500w',
+		    'https://c2.staticflickr.com/8/7538/15535067073_5835371a5f_n.jpg 320w'
+		]
+    },
+    {
+	src: 'https://c2.staticflickr.com/8/7550/15532469404_e39e2fe2e8_c.jpg',
+	thumbnail: 'https://c2.staticflickr.com/8/7550/15532469404_e39e2fe2e8_s.jpg',
+	srcset: [
+		    'https://c2.staticflickr.com/8/7550/15532469404_e39e2fe2e8_b.jpg 1024w',
+		    'https://c2.staticflickr.com/8/7550/15532469404_e39e2fe2e8_c.jpg 800w',
+		    'https://c2.staticflickr.com/8/7550/15532469404_e39e2fe2e8.jpg 500w',
+		    'https://c2.staticflickr.com/8/7550/15532469404_e39e2fe2e8_n.jpg 320w'
+		]
+    },
+    {
+	src: 'https://c2.staticflickr.com/8/7581/16129016486_085eb8dedd_c.jpg',
+	thumbnail: 'https://c2.staticflickr.com/8/7581/16129016486_085eb8dedd_s.jpg',
+	srcset: [
+		    'https://c2.staticflickr.com/8/7581/16129016486_085eb8dedd_b.jpg 1024w',
+		    'https://c2.staticflickr.com/8/7581/16129016486_085eb8dedd_c.jpg 800w',
+		    'https://c2.staticflickr.com/8/7581/16129016486_085eb8dedd.jpg 500w',
+		    'https://c2.staticflickr.com/8/7581/16129016486_085eb8dedd_n.jpg 320w'
+		]
+    },
 ];
-
-const THUMBNAILS = [
-	'https://c1.staticflickr.com/9/8383/8517694980_21bef8e9fc_s.jpg',
-        'https://c1.staticflickr.com/9/8379/8516580741_058e7c7317_s.jpg',
-        'https://c1.staticflickr.com/9/8509/8517695778_f08f11150f_s.jpg',
-        'https://c1.staticflickr.com/9/8109/8526026980_a152c5f11d_s.jpg',
-        'https://c1.staticflickr.com/9/8243/8524916085_ed79b45249_s.jpg',
-        'https://c2.staticflickr.com/8/7489/16129020136_f36604d33f_s.jpg',
-        
-        'https://c1.staticflickr.com/9/8376/8526026438_a06baf0f58_s.jpg',
-        'https://c1.staticflickr.com/9/8225/8524911453_598b176b7e_s.jpg',
-        'https://c1.staticflickr.com/9/8513/8533369906_96f03a6434_s.jpg',
-        'https://c1.staticflickr.com/9/8096/8532223657_b1efa18ac8_s.jpg',
-        'https://c1.staticflickr.com/9/8390/8532222553_e0e05dbdd6_s.jpg',
-        'https://c1.staticflickr.com/9/8513/8533333694_736fc6c9af_s.jpg',
-        
-        'https://c1.staticflickr.com/9/8391/8532223463_abe07ac0a6_s.jpg',
-        'https://c1.staticflickr.com/9/8365/8529344273_eedda51ea1_s.jpg',
-        'https://c1.staticflickr.com/9/8381/8527501230_61882a7918_s.jpg',
-        'https://c2.staticflickr.com/8/7538/15535067073_5835371a5f_s.jpg',
-        'https://c2.staticflickr.com/8/7550/15532469404_e39e2fe2e8_s.jpg',
-        'https://c2.staticflickr.com/8/7581/16129016486_085eb8dedd_s.jpg',
-]; 
 const styles = Lightbox.extendStyles({
 	image: {
 		border: '10px solid white',
@@ -67,8 +192,8 @@ const styles = Lightbox.extendStyles({
 render(
 	<div>
 		<p style={{ marginBottom: 40 }}>Use your keyboard to navigate <kbd>left</kbd> <kbd>right</kbd> <kbd>esc</kbd> &mdash; Also, try resizing your browser window.</p>
-		<Gallery heading="Gallery" images={IMAGES} thumbnails={THUMBNAILS} />
-		<Gallery heading="Custom Styles" images={IMAGES} thumbnails={THUMBNAILS} styles={styles} />
+		<Gallery heading="Gallery" images={IMAGES} />
+		<Gallery heading="Custom Styles" images={IMAGES} styles={styles} />
 		<Button heading="Launch with a button" images={IMAGES} />
 		<hr />
 		<p className="hint">

--- a/examples/src/components/Gallery.js
+++ b/examples/src/components/Gallery.js
@@ -5,7 +5,7 @@ var Standard = React.createClass({
 	displayName: 'Standard',
 	propTypes: {
 		images: React.PropTypes.array,
-		thumbs: React.PropTypes.array,
+		thumbnails: React.PropTypes.array,
 		heading: React.PropTypes.string,
 		subheading: React.PropTypes.string,
 		sepia: React.PropTypes.bool,
@@ -28,12 +28,12 @@ var Standard = React.createClass({
 		});
 	},
 	renderGallery () {
-		if (!this.props.thumbs) return;
+		if (!this.props.thumbnails) return;
 
 		let gallery = this.props.images.map((url, i) => {
 			return (
 				<a key={i} href={url} onClick={this.openLightbox.bind(this, i)} style={Object.assign({}, styles.thumbnail)}>
-				    <img src={this.props.thumbs[i]} width={styles.thumbnail.size} height={styles.thumbnail.size} />
+				    <img src={this.props.thumbnails[i]} width={styles.thumbnail.size} height={styles.thumbnail.size} />
 				</a>
 			);
 		});

--- a/examples/src/components/Gallery.js
+++ b/examples/src/components/Gallery.js
@@ -5,6 +5,7 @@ var Standard = React.createClass({
 	displayName: 'Standard',
 	propTypes: {
 		images: React.PropTypes.array,
+		thumbs: React.PropTypes.array,
 		heading: React.PropTypes.string,
 		subheading: React.PropTypes.string,
 		sepia: React.PropTypes.bool,
@@ -27,11 +28,13 @@ var Standard = React.createClass({
 		});
 	},
 	renderGallery () {
-		if (!this.props.images) return;
+		if (!this.props.thumbs) return;
 
 		let gallery = this.props.images.map((url, i) => {
 			return (
-				<a key={i} href={url} onClick={this.openLightbox.bind(this, i)} style={Object.assign({}, styles.thumbnail, { backgroundImage: `url(${url})` })} />
+				<a key={i} href={url} onClick={this.openLightbox.bind(this, i)} style={Object.assign({}, styles.thumbnail)}>
+				    <img src={this.props.thumbs[i]} width={styles.thumbnail.size} height={styles.thumbnail.size} />
+				</a>
 			);
 		});
 

--- a/examples/src/components/Gallery.js
+++ b/examples/src/components/Gallery.js
@@ -5,7 +5,6 @@ var Standard = React.createClass({
 	displayName: 'Standard',
 	propTypes: {
 		images: React.PropTypes.array,
-		thumbnails: React.PropTypes.array,
 		heading: React.PropTypes.string,
 		subheading: React.PropTypes.string,
 		sepia: React.PropTypes.bool,
@@ -28,12 +27,11 @@ var Standard = React.createClass({
 		});
 	},
 	renderGallery () {
-		if (!this.props.thumbnails) return;
-
-		let gallery = this.props.images.map((url, i) => {
+		if (!this.props.images) return;
+		let gallery = this.props.images.map((obj, i) => {
 			return (
-				<a key={i} href={url} onClick={this.openLightbox.bind(this, i)} style={Object.assign({}, styles.thumbnail)}>
-				    <img src={this.props.thumbnails[i]} width={styles.thumbnail.size} height={styles.thumbnail.size} />
+				<a key={i} href={obj.src} onClick={this.openLightbox.bind(this, i)} style={Object.assign({}, styles.thumbnail)}>
+				    <img src={obj.thumbnail} width={styles.thumbnail.size} height={styles.thumbnail.size} />
 				</a>
 			);
 		});
@@ -56,6 +54,7 @@ var Standard = React.createClass({
 					isOpen={this.state.lightboxIsOpen}
 					onClose={this.closeLightbox}
 					styles={this.props.styles}
+					width={1200}
 				/>
 			</div>
 		);

--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -167,11 +167,9 @@ var Lightbox = React.createClass({
 
 	        if (images[currentImage].srcset){
 		    // if srcset is provided
-console.log('yes');
 		    var img = <img src={images[currentImage].src} srcSet={images[currentImage].srcset.join()} sizes={parseInt(this.props.styles.image.maxWidth)+'vw'} style={this.props.styles.image} onTouchEnd={e => e.stopPropagation()} onClick={e => e.stopPropagation()} />
 		}
 		else{
-console.log('no');
 		    var img = <img src={images[currentImage].src} style={this.props.styles.image} onTouchEnd={e => e.stopPropagation()} onClick={e => e.stopPropagation()} />
 
 		}

--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -165,10 +165,20 @@ var Lightbox = React.createClass({
 		let { currentImage } = this.state;
 		if (!images || !images.length) return;
 
+	        if (images[currentImage].srcset){
+		    // if srcset is provided
+console.log('yes');
+		    var img = <img src={images[currentImage].src} srcSet={images[currentImage].srcset.join()} sizes={parseInt(this.props.styles.image.maxWidth)+'vw'} style={this.props.styles.image} onTouchEnd={e => e.stopPropagation()} onClick={e => e.stopPropagation()} />
+		}
+		else{
+console.log('no');
+		    var img = <img src={images[currentImage].src} style={this.props.styles.image} onTouchEnd={e => e.stopPropagation()} onClick={e => e.stopPropagation()} />
+
+		}
 		return (
 			<Transition transitionName="div" component="div">
 				<Fade key={'image' + currentImage}>
-					<img src={images[currentImage]} style={this.props.styles.image} onTouchEnd={e => e.stopPropagation()} onClick={e => e.stopPropagation()} />
+				    {img}
 				</Fade>
 			</Transition>
 		);

--- a/src/styles/default.js
+++ b/src/styles/default.js
@@ -28,7 +28,7 @@ const styles = {
 		left: 0,
 	},
 	backdrop: {
-		backgroundColor: 'rgba(0,0,0,0.66)',
+		backgroundColor: 'rgba(0,0,0,0.76)',
 		bottom: 0,
 		left: 0,
 		position: 'fixed',


### PR DESCRIPTION
These are some changes before committing srcset support.
A few things:

-Unfortunately I could not find a single image placeholder generator site that provided multiple sizes, including square thumbnail sizes of the same image in order to have several sizes for srcset support examples (including the http://lorempixel.com/ site i mentioned).  The easiest thing I found was to just use Flickr which provides several common sizes for any image including small thumbs.  I own the copyright to all these images and they are free to use.

-Separate out thumbnail images from larger Lightbox images into its own array.  Eventually I think the array can be an array of objects with srcset and thumbnail items.

-Darken the backdrop to the Lightbox.  Found the background to be a bit distracting being so light previously.