### PR TITLE
Adding optional captions to be shown in the Lightbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,39 +38,7 @@ npm start
 
 Then open [`localhost:8000`](http://localhost:8000) in a browser.
 
-Example using caption for the first image:
-
-```jsx
-<Lightbox
-  images={LIGHTBOX_IMAGE_SET}
-  onClickPrev={this.gotoPrevious}
-  onClickNext={this.gotoNext}
-  onClose={this.closeLightbox}
-/>
-
-const LIGHTBOX_IMAGE_SET = [
-  {
-    src: 'http://example.com/example/img1.jpg',
-    srcset: [
-      'http://example.com/example/img1_1024.jpg 1024w',
-      'http://example.com/example/img1_800.jpg 800w',
-      'http://example.com/example/img1_500.jpg 500w',
-      'http://example.com/example/img1_320.jpg 320w',
-    ],
-    caption: 'Lorem ipsum',
-  },
-  {
-    src: 'http://example.com/example/img2.jpg',
-    srcset: [
-      'http://example.com/example/img2_1024.jpg 1024w',
-      'http://example.com/example/img2_800.jpg 800w',
-      'http://example.com/example/img2_500.jpg 500w',
-      'http://example.com/example/img2_320.jpg 320w',
-    ],
-  }
-];
-
-```
+### Using srcset
 
 Example using srcset:
 ```jsx
@@ -112,6 +80,43 @@ Another thing to note is that 'h' or height in the srcset attribute does not yet
 
 Read more about the srcset and sizes attributes here: [https://ericportis.com/posts/2014/srcset-sizes/](https://ericportis.com/posts/2014/srcset-sizes/).
 
+### Adding Captions
+
+Example using caption for the first image:
+
+```jsx
+<Lightbox
+  images={LIGHTBOX_IMAGE_SET}
+  onClickPrev={this.gotoPrevious}
+  onClickNext={this.gotoNext}
+  onClose={this.closeLightbox}
+/>
+
+const LIGHTBOX_IMAGE_SET = [
+  {
+    src: 'http://example.com/example/img1.jpg',
+    srcset: [
+      'http://example.com/example/img1_1024.jpg 1024w',
+      'http://example.com/example/img1_800.jpg 800w',
+      'http://example.com/example/img1_500.jpg 500w',
+      'http://example.com/example/img1_320.jpg 320w',
+    ],
+    caption: 'Lorem ipsum',
+  },
+  {
+    src: 'http://example.com/example/img2.jpg',
+    srcset: [
+      'http://example.com/example/img2_1024.jpg 1024w',
+      'http://example.com/example/img2_800.jpg 800w',
+      'http://example.com/example/img2_500.jpg 500w',
+      'http://example.com/example/img2_320.jpg 320w',
+    ],
+  }
+];
+
+```
+
+Note that the caption is an entirely optional property, as can be seen in the first gallery on the [example page](http://jossmac.github.io/react-images/). The first image has a single line caption, the second demonstrates multiline, and the remaining images are without captions, entirely.
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,40 @@ npm start
 
 Then open [`localhost:8000`](http://localhost:8000) in a browser.
 
+Example using caption for the first image:
+
+```jsx
+<Lightbox
+  images={LIGHTBOX_IMAGE_SET}
+  onClickPrev={this.gotoPrevious}
+  onClickNext={this.gotoNext}
+  onClose={this.closeLightbox}
+/>
+
+const LIGHTBOX_IMAGE_SET = [
+  {
+    src: 'http://example.com/example/img1.jpg',
+    srcset: [
+      'http://example.com/example/img1_1024.jpg 1024w',
+      'http://example.com/example/img1_800.jpg 800w',
+      'http://example.com/example/img1_500.jpg 500w',
+      'http://example.com/example/img1_320.jpg 320w',
+    ],
+    caption: 'Lorem ipsum',
+  },
+  {
+    src: 'http://example.com/example/img2.jpg',
+    srcset: [
+      'http://example.com/example/img2_1024.jpg 1024w',
+      'http://example.com/example/img2_800.jpg 800w',
+      'http://example.com/example/img2_500.jpg 500w',
+      'http://example.com/example/img2_320.jpg 320w',
+    ],
+  }
+];
+
+```
+
 Example using srcset:
 ```jsx
 <Lightbox

--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -16,6 +16,7 @@ const IMAGES = [
 			'https://c1.staticflickr.com/9/8383/8517694980_21bef8e9fc.jpg 500w',
 			'https://c1.staticflickr.com/9/8383/8517694980_21bef8e9fc_n.jpg 320w'
 		],
+    caption: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
 	},
 	{
 	src: 'https://c1.staticflickr.com/9/8379/8516580741_058e7c7317_c.jpg',
@@ -25,7 +26,8 @@ const IMAGES = [
 			'https://c1.staticflickr.com/9/8379/8516580741_058e7c7317_c.jpg 800w',
 			'https://c1.staticflickr.com/9/8379/8516580741_058e7c7317.jpg 500w',
 			'https://c1.staticflickr.com/9/8379/8516580741_058e7c7317_n.jpg 320w'
-		]
+		],
+    caption: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
 	},
 	{
 	src: 'https://c1.staticflickr.com/9/8509/8517695778_f08f11150f_c.jpg',

--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -16,7 +16,7 @@ const IMAGES = [
 			'https://c1.staticflickr.com/9/8383/8517694980_21bef8e9fc.jpg 500w',
 			'https://c1.staticflickr.com/9/8383/8517694980_21bef8e9fc_n.jpg 320w'
 		],
-    caption: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+	caption: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
 	},
 	{
 	src: 'https://c1.staticflickr.com/9/8379/8516580741_058e7c7317_c.jpg',
@@ -27,7 +27,7 @@ const IMAGES = [
 			'https://c1.staticflickr.com/9/8379/8516580741_058e7c7317.jpg 500w',
 			'https://c1.staticflickr.com/9/8379/8516580741_058e7c7317_n.jpg 320w'
 		],
-    caption: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+	caption: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
 	},
 	{
 	src: 'https://c1.staticflickr.com/9/8509/8517695778_f08f11150f_c.jpg',

--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -21,6 +21,7 @@ var Lightbox = React.createClass({
 			PropTypes.shape({
 				src: PropTypes.string.isRequired,
 				srcset: PropTypes.array,
+                caption: PropTypes.string
 			})
 		).isRequired,
 		isOpen: PropTypes.bool,
@@ -162,6 +163,8 @@ var Lightbox = React.createClass({
 	},
 	renderImages () {
 		let { images, currentImage } = this.props;
+        let caption = images[currentImage].caption || "";
+
 		if (!images || !images.length) return;
 
 		if (images[currentImage].srcset) {
@@ -173,6 +176,7 @@ var Lightbox = React.createClass({
 			<Transition transitionName="div" component="div">
 				<Fade key={'image' + currentImage}>
 					{img}
+                    <p style={this.props.styles.caption}>{caption}</p>
 				</Fade>
 			</Transition>
 		);

--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -21,7 +21,7 @@ var Lightbox = React.createClass({
 			PropTypes.shape({
 				src: PropTypes.string.isRequired,
 				srcset: PropTypes.array,
-                caption: PropTypes.string
+				caption: PropTypes.string
 			})
 		).isRequired,
 		isOpen: PropTypes.bool,
@@ -163,7 +163,7 @@ var Lightbox = React.createClass({
 	},
 	renderImages () {
 		let { images, currentImage } = this.props;
-        let caption = images[currentImage].caption || "";
+		let caption = images[currentImage].caption || "";
 
 		if (!images || !images.length) return;
 
@@ -176,7 +176,7 @@ var Lightbox = React.createClass({
 			<Transition transitionName="div" component="div">
 				<Fade key={'image' + currentImage}>
 					{img}
-                    <p style={this.props.styles.caption}>{caption}</p>
+					<p style={this.props.styles.caption}>{caption}</p>
 				</Fade>
 			</Transition>
 		);

--- a/src/styles/default.js
+++ b/src/styles/default.js
@@ -95,6 +95,22 @@ const styles = {
 		userSelect:         'none',
 
 	},
+    caption: {
+        position: 'absolute',
+
+        // placed under the image
+        bottom: '-45px',
+
+		// center the caption within the dialog
+		left: '50%',
+		WebkitTransform: 'translate(-50%, 50%)',
+		MozTransform:    'translate(-50%, 50%)',
+		msTransform:     'translate(-50%, 50%)',
+		transform:       'translate(-50%, 50%)',
+
+        // visibility
+        color: 'white',
+    },
 };
 
 export default styles;

--- a/src/styles/default.js
+++ b/src/styles/default.js
@@ -95,11 +95,11 @@ const styles = {
 		userSelect:         'none',
 
 	},
-    caption: {
-        position: 'absolute',
+	caption: {
+		position: 'absolute',
 
-        // placed under the image
-        bottom: '-45px',
+		// placed under the image
+		bottom: '-45px',
 
 		// center the caption within the dialog
 		left: '50%',
@@ -108,9 +108,9 @@ const styles = {
 		msTransform:     'translate(-50%, 50%)',
 		transform:       'translate(-50%, 50%)',
 
-        // visibility
-        color: 'white',
-    },
+		// visibility
+		color: 'white',
+	},
 };
 
 export default styles;


### PR DESCRIPTION
This adds a possible 'caption' property to the elements within an 'images' list. 

Testing with the generated examples page shows that it is backward compatible for those who do not provide captions. This can be seen in the first 3 images of the first Gallery within examples/src/app.js--as described in the updated README.