### PR TITLE
modify close button, caption, count to be absolutely positioned to ta…

### DIFF
--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -22,7 +22,7 @@ import Portal from './Portal';
 import defaultStyles from './styles/default';
 
 class Lightbox extends Component {
-	static theme (themeStyles) {
+    static theme (themeStyles) {
 		const extStyles = Object.assign({}, defaultStyles);
 		for (const key in extStyles) {
 			if (key in themeStyles) {
@@ -220,6 +220,7 @@ class Lightbox extends Component {
 		const { images, currentImage } = this.props;
 		const { classes } = this.props.sheet;
 		const { windowHeight } = this.state;
+		const imageDetailSpace = 90;
 
 		if (!images || !images.length) return null;
 
@@ -246,7 +247,7 @@ class Lightbox extends Component {
 						srcSet={srcset}
 						style={{
 							cursor: this.props.onClickImage ? 'pointer' : 'auto',
-							maxHeight: windowHeight,
+							maxHeight: windowHeight - imageDetailSpace,
 						}}
 					/>
 				</Swipeable>

--- a/src/styles/default.js
+++ b/src/styles/default.js
@@ -1,6 +1,7 @@
 const CLOSE_SIZE = 20;
 const ARROW_HEIGHT = 120;
 const GAP_BOTTOM = 50;
+const CAPTION_COUNT_HEIGHT = 25;
 const GAP_TOP = 40;
 
 const styles = {
@@ -38,8 +39,6 @@ const styles = {
 		lineHeight: 0,
 		maxWidth: '100%',
 		margin: '0 auto',
-		paddingBottom: 50,
-		paddingTop: 40,
 		height: 'auto',
 		width: 'auto',
 
@@ -73,9 +72,7 @@ const styles = {
 	footer: {
 		color: 'white',
 		lineHeight: 1.3,
-		height: GAP_BOTTOM,
-		marginTop: -GAP_BOTTOM,
-		paddingTop: 5,
+		marginTop: -CAPTION_COUNT_HEIGHT + 5,
 		position: 'absolute',
 		textAlign: 'left',
 		top: '100%',
@@ -84,12 +81,17 @@ const styles = {
 		cursor: 'auto',
 	},
 	footerCount: {
-		float: 'right',
+		display: 'inline-block',
+		position: 'absolute',
+		right: 0,	
+		top: CAPTION_COUNT_HEIGHT,
 		fontSize: '.85em',
 		opacity: 0.75,
 	},
 	footerCaption: {
-		paddingRight: 80,
+	    display: 'inline-block',
+	    position: 'absolute',
+	    top: CAPTION_COUNT_HEIGHT,
 	},
 
 	// BUTTONS
@@ -122,11 +124,12 @@ const styles = {
 	},
 	closeBar: {
 		height: GAP_TOP,
-		left: 0,
+		right:0,
 		position: 'absolute',
 		textAlign: 'right',
-		top: 0,
-		width: '100%',
+		top: -40,
+		width:40,
+		minHeight:40,
 	},
 	closeButton: {
 		background: 'none',


### PR DESCRIPTION
I find it really annoying that when i set "backdropClosesModal" to true, when trying to click anywhere near the left of the X (to close) button or around the center of the bottom of the image it fails to close the modal due to an unnecessary wrapper div around these elements.  These elements being the close button, the caption text, and the photo count.

I've changed things around so that the maxHeight of the image is set to windowHeight - (however much space is needed at top and bottom which was 90px and removed the image padding).

Then i changed the css around to make elements inline-block and positioned absolutely.

I don't believe there is a need for the 'GAP_BOTTOM' JSS variable as i replaced it with something a bit more descriptive for what is now being calculated which is 'CAPTION_COUNT_HEIGHT'.  But it seems 'figureShadow' is using it, though i don't see where 'figureShadow' is being used.  Let me know if I can remove that or if you have any other questions and I'd be glad to modify the code accordingly.