### PR TITLE
Fixes #68

### DIFF
--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -47,12 +47,15 @@ class Lightbox extends Component {
 	componentWillReceiveProps (nextProps) {
 		if (!utils.canUseDom) return;
 
-		if (nextProps.isOpen && nextProps.enableKeyboardInput) {
+		if(nextProps.enableKeyboardInput){
 			window.addEventListener('keydown', this.handleKeyboardInput);
+		} else {
+			window.removeEventListener('keydown', this.handleKeyboardInput);
+		}
+		if (nextProps.isOpen) {
 			window.addEventListener('resize', this.handleResize);
 			this.handleResize();
 		} else {
-			window.removeEventListener('keydown', this.handleKeyboardInput);
 			window.removeEventListener('resize', this.handleResize);
 		}
 


### PR DESCRIPTION
enableKeyboardInput true was explicitly linked to resize event. Setting enableKeyboardInput to false removed the resize event listener and therefore handleResize was never called thus image rendered with windowHeight 0 (setting img max-height to 0px).