### PR TITLE
Remove keyboard input event handler upon unmount

### DIFF
--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -67,6 +67,11 @@ class Lightbox extends Component {
 			bodyScroll.allowScroll();
 		}
 	}
+	componentWillUnmount () {
+		if (this.props.enableKeyboardInput) {
+			window.removeEventListener('keydown', this.handleKeyboardInput);
+		}
+	}
 
 	// ==============================
 	// METHODS


### PR DESCRIPTION
When the component is unmounted, remove its keyboard input handler. Otherwise the input handlers of past Lightbox instances will linger and cause havoc.

Fixes #76.