### PR TITLE
Fixed keydown listener

### DIFF
--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -28,6 +28,11 @@ class Lightbox extends Component {
 			theme: this.props.theme,
 		};
 	}
+	componentDidMount() {
+		if (this.props.enableKeyboardInput) {
+			window.addEventListener('keydown', this.handleKeyboardInput);
+		}
+	}
 	componentWillReceiveProps (nextProps) {
 		if (!canUseDom) return;
 
@@ -55,9 +60,10 @@ class Lightbox extends Component {
 		}
 
 		// add event listeners
-		if (nextProps.enableKeyboardInput) {
+		if (!this.props.enableKeyboardInput && nextProps.enableKeyboardInput) {
 			window.addEventListener('keydown', this.handleKeyboardInput);
-		} else {
+		}
+		if (this.props.enableKeyboardInput && !nextProps.enableKeyboardInput) {
 			window.removeEventListener('keydown', this.handleKeyboardInput);
 		}
 	}


### PR DESCRIPTION
When the prop `isOpen` is true by default, the component doesn't attach the event listener for "keydown"

My demo: https://github.com/archr/react-images-demo
