### PR TITLE
(readme): make basic example more informative

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ export default class Sample extends React.Component {
           isOpen={lightboxIsOpen}
           onClickPrev={this.gotoPrevious}
           onClickNext={this.gotoNext}
-          onClose={this.closeLightbox}
+          onClose={this.onClose}
         />
       </div>
     );

--- a/README.md
+++ b/README.md
@@ -18,17 +18,48 @@ import Lightbox from 'react-images';
 
 export default class Sample extends React.Component {
   ...
+
+  state = {
+    currentImage: 0,
+    lightboxIsOpen: false,
+    images: [{ src: 'http://example.com/img1.jpg' }, { src: 'http://example.com/img2.jpg' }]
+  }
+
   render() {
+    const { currentImage, images, lightboxIsOpen } = this.state
     return (
-      <Lightbox
-        images={[{ src: 'http://example.com/img1.jpg' }, { src: 'http://example.com/img2.jpg' }]}
-        isOpen={this.state.lightboxIsOpen}
-        onClickPrev={this.gotoPrevious}
-        onClickNext={this.gotoNext}
-        onClose={this.closeLightbox}
-      />
+      <div>
+        <button onClick={this.onOpen}>Open</button>
+        <Lightbox
+          currentImage: currentImage
+          images={images}
+          isOpen={lightboxIsOpen}
+          onClickPrev={this.gotoPrevious}
+          onClickNext={this.gotoNext}
+          onClose={this.closeLightbox}
+        />
+      </div>
     );
   }
+
+  onOpen = evt => {
+    this.setState({ lightboxIsOpen: true })
+  }
+
+  onClose = evt => {
+    this.setState({ lightboxIsOpen: false })
+  }
+
+  onClickPrev = evt => {
+    this.setState({ currentImage: Math.max(0, this.state.currentImage - 1) })
+  }
+
+  onClickNext = evt => {
+    this.setState({
+      currentImage: Math.min(this.state.images.length - 1, this.state.currentImage + 1)
+    })
+  }
+
 }
 ```
 
@@ -112,9 +143,9 @@ Note that the caption is an entirely optional property, as can be seen in the fi
 
 ## Options
 
-Property	|	Type		|	Default		|	Description
+Property  | Type    | Default   | Description
 :-----------------------|:--------------|:--------------|:--------------------------------
-backdropClosesModal	|	bool	|	false	|	Allow users to exit the lightbox by clicking the backdrop
+backdropClosesModal | bool  | false | Allow users to exit the lightbox by clicking the backdrop
 closeButtonTitle | string | ' Close (Esc) ' | Customize close esc title
 enableKeyboardInput | bool  | true  | Supports keyboard input - <code>esc</code>, <code>arrow left</code>, and <code>arrow right</code>
 currentImage  | number  | 0 | The index of the image to display initially


### PR DESCRIPTION
### Motivation
The previous readme is not exhaustive enough and leads to confusion by users, see #115 for example

### Changes
add to quick start example examples of the following:
- onOpen
- onClose
- onClickPrev
- onClickNext

should resolve #115

<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

**Description of changes:**


**Related issues (if any):**


**Checks:**

- [ ] Please confirm `npm run lint` ran successfully
- [ ] Please confirm that only `/src` and `/examples/src` are committed
- [ ] [if new feature] Please confirm that documentation was added to the README.md
