### PR TITLE
fix typo in renderArrowNext ()

### DIFF
--- a/src/components/PaginatedThumbnails.js
+++ b/src/components/PaginatedThumbnails.js
@@ -118,7 +118,7 @@ export default class PaginatedThumbnails extends Component {
 				icon="arrowRight"
 				onClick={this.gotoNext}
 				style={arrowStyles}
-				title="Previous (Right arrow key)"
+				title="Next (Right arrow key)"
 				type="button"
 			/>
 		);


### PR DESCRIPTION
The **title** prop for the Arrow component in renderArrowNext () should be **Next (Right arrow key)** not **Previous (Right arrow key)**