### PR TITLE
Allow user to specify where to render customControls

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ closeButtonTitle | string | ' Close (Esc) ' | Customize close esc title
 enableKeyboardInput | bool  | true  | Supports keyboard input - <code>esc</code>, <code>arrow left</code>, and <code>arrow right</code>
 currentImage  | number  | 0 | The index of the image to display initially
 customControls | array | undefined | An array of elements to display as custom controls on the top of lightbox
+customControlsPosition | string | 'TOP' | Indicates where to render customControls in the lightbox. Can be 'TOP' or 'BOTTOM'
 images  | array | undefined | Required. An array of objects containing valid src and srcset values of img element
 imageCountSeparator  | String  | ' of ' | Customize separator in the image count
 isOpen  | bool  | false | Whether or not the lightbox is displayed

--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -155,10 +155,8 @@ class Lightbox extends Component {
 	renderDialog () {
 		const {
 			backdropClosesModal,
-			customControls,
 			isOpen,
 			onClose,
-			showCloseButton,
 			showThumbnails,
 			width,
 		} = this.props;
@@ -177,12 +175,7 @@ class Lightbox extends Component {
 				onTouchEnd={!!backdropClosesModal && onClose}
 			>
 				<div className={css(classes.content)} style={{ marginBottom: offsetThumbnails, maxWidth: width }}>
-					<Header
-						customControls={customControls}
-						onClose={onClose}
-						showCloseButton={showCloseButton}
-						closeButtonTitle={this.props.closeButtonTitle}
-					/>
+					{this.renderHeader()}
 					{this.renderImages()}
 				</div>
 				{this.renderThumbnails()}
@@ -192,13 +185,30 @@ class Lightbox extends Component {
 			</Container>
 		);
 	}
+	renderHeader () {
+		const {
+			customControlsPosition,
+			onClose,
+			showCloseButton,
+			closeButtonTitle,
+		} = this.props;
+
+		const topControls = customControlsPosition !== 'BOTTOM' ? this.props.customControls : null;
+
+		return (
+			<Header
+				customControls={topControls}
+				onClose={onClose}
+				showCloseButton={showCloseButton}
+				closeButtonTitle={closeButtonTitle}
+			/>
+		);
+	}
 	renderImages () {
 		const {
 			currentImage,
 			images,
-			imageCountSeparator,
 			onClickImage,
-			showImageCount,
 			showThumbnails,
 		} = this.props;
 
@@ -236,14 +246,30 @@ class Lightbox extends Component {
 						maxHeight: `calc(100vh - ${heightOffset})`,
 					}}
 				/>
-				<Footer
-					caption={images[currentImage].caption}
-					countCurrent={currentImage + 1}
-					countSeparator={imageCountSeparator}
-					countTotal={images.length}
-					showCount={showImageCount}
-				/>
+				{this.renderFooter()}
 			</figure>
+		);
+	}
+	renderFooter () {
+		const {
+			images,
+			currentImage,
+			imageCountSeparator,
+			showImageCount,
+			customControlsPosition,
+		} = this.props;
+
+		const bottomControls = customControlsPosition === 'BOTTOM' ? this.props.customControls : null;
+
+		return (
+			<Footer
+				customControls={bottomControls}
+				caption={images[currentImage].caption}
+				countCurrent={currentImage + 1}
+				countSeparator={imageCountSeparator}
+				countTotal={images.length}
+				showCount={showImageCount}
+			/>
 		);
 	}
 	renderThumbnails () {
@@ -301,6 +327,7 @@ Lightbox.propTypes = {
 };
 Lightbox.defaultProps = {
 	closeButtonTitle: 'Close (Esc)',
+	customControlsPosition: 'TOP',
 	currentImage: 0,
 	enableKeyboardInput: true,
 	imageCountSeparator: ' of ',

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -9,6 +9,7 @@ function Footer ({
 	countSeparator,
 	countTotal,
 	showCount,
+	customControls,
 	...props,
 }, {
 	theme,
@@ -32,6 +33,7 @@ function Footer ({
 					{caption}
 				</figcaption>
 			) : <span />}
+			{customControls ? customControls : <span />}
 			{imageCount}
 		</div>
 	);


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

**Description of changes:**
Allow a **customControlsPosition** prop to be passed to the Lightbox component to specify where the **customControls** prop should be rendered. If 'TOP' then the **customControls** will be rendered in the Header component. If 'BOTTOM' then the **customControls** will be rendered in the Footer component. If **customControlsPosition** is not specified the default is 'TOP' and to render in the Header component.


**Checks:**

- [x] Please confirm `npm run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed
- [x] [if new feature] Please confirm that documentation was added to the README.md
