### PR TITLE
Remove deprecation warnings (PropTypes)

### DIFF
--- a/examples/src/components/DownloadButton/index.js
+++ b/examples/src/components/DownloadButton/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import DownloadIcon from './icon';
 
 class DownloadButton extends Component {

--- a/examples/src/components/Gallery.js
+++ b/examples/src/components/Gallery.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { css, StyleSheet } from 'aphrodite/no-important';
 import Lightbox from 'react-images';
 
@@ -96,7 +97,7 @@ class Gallery extends Component {
 			</div>
 		);
 	}
-};
+}
 
 Gallery.displayName = 'Gallery';
 Gallery.propTypes = {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "aphrodite": "^0.5.0",
+    "prop-types": "^15.5.8",
     "react-addons-css-transition-group": "^15.3.0",
     "react-scrolllock": "^1.0.5"
   },

--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { css, StyleSheet } from 'aphrodite/no-important';
 import ScrollLock from 'react-scrolllock';
 

--- a/src/components/Arrow.js
+++ b/src/components/Arrow.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { css, StyleSheet } from 'aphrodite/no-important';
 
 import defaults from '../theme';
@@ -28,7 +29,7 @@ function Arrow ({
 			<Icon fill={!!theme.arrow && theme.arrow.fill || defaults.arrow.fill} type={icon} />
 		</button>
 	);
-};
+}
 
 Arrow.propTypes = {
 	direction: PropTypes.oneOf(['left', 'right']),

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { css, StyleSheet } from 'aphrodite/no-important';
 
 import defaults from '../theme';
@@ -13,7 +14,7 @@ function Container ({ ...props }, { theme }) {
 			{...props}
 		/>
 	);
-};
+}
 
 Container.contextTypes = {
 	theme: PropTypes.object.isRequired,

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { css, StyleSheet } from 'aphrodite/no-important';
 import defaults from '../theme';
 import { deepMerge } from '../utils';
@@ -35,7 +36,7 @@ function Footer ({
 			{imageCount}
 		</div>
 	);
-};
+}
 
 Footer.propTypes = {
 	caption: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { css, StyleSheet } from 'aphrodite/no-important';
 
 import defaults from '../theme';
@@ -30,7 +31,7 @@ function Header ({
 			)}
 		</div>
 	);
-};
+}
 
 Header.propTypes = {
 	customControls: PropTypes.array,

--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import icons from '../icons';
 
 const Icon = ({ fill, type, ...props }) => {

--- a/src/components/PaginatedThumbnails.js
+++ b/src/components/PaginatedThumbnails.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { css, StyleSheet } from 'aphrodite/no-important';
 
 import Thumbnail from './Thumbnail';

--- a/src/components/PassContext.js
+++ b/src/components/PassContext.js
@@ -1,4 +1,5 @@
-import { Children, Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import { Children, Component } from 'react';
 
 // Pass the Lightbox context through to the Portal's descendents
 // StackOverflow discussion http://goo.gl/oclrJ9
@@ -10,7 +11,7 @@ class PassContext extends Component {
 	render () {
 		return Children.only(this.props.children);
 	}
-};
+}
 
 PassContext.propTypes = {
 	context: PropTypes.object.isRequired,

--- a/src/components/Portal.js
+++ b/src/components/Portal.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import Transition from 'react-addons-css-transition-group';
 import { render } from 'react-dom';
 import PassContext from './PassContext';

--- a/src/components/Thumbnail.js
+++ b/src/components/Thumbnail.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { css, StyleSheet } from 'aphrodite/no-important';
 
 import defaults from '../theme';

--- a/src/components/Thumbnails.js
+++ b/src/components/Thumbnails.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { css, StyleSheet } from 'aphrodite/no-important';
 import Thumbnail from './Thumbnail';
 


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

**Description of changes:**
Remove deprecation warnings for React v16.
Used this [codemod](https://github.com/reactjs/react-codemod).


**Related issues (if any):**
#132 


**Checks:**

- [x] Please confirm `npm run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed
- [ ] [if new feature] Please confirm that documentation was added to the README.md
