### PR TITLE
Remove isOpen prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ export default class Sample extends React.Component {
     return (
       <Lightbox
         images={[{ src: 'http://example.com/img1.jpg' }, { src: 'http://example.com/img2.jpg' }]}
-        isOpen={this.state.lightboxIsOpen}
         onClickPrev={this.gotoPrevious}
         onClickNext={this.gotoNext}
         onClose={this.closeLightbox}
@@ -121,7 +120,6 @@ currentImage  | number  | 0 | The index of the image to display initially
 customControls | array | undefined | An array of elements to display as custom controls on the top of lightbox
 images  | array | undefined | Required. An array of objects containing valid src and srcset values of img element
 imageCountSeparator  | String  | ' of ' | Customize separator in the image count
-isOpen  | bool  | false | Whether or not the lightbox is displayed
 leftArrowTitle | string | ' Previous (Left arrow key) ' | Customize of left arrow title
 onClickPrev | func | undefined | Fired on request of the previous image
 onClickNext | func | undefined | Fired on request of the next image

--- a/examples/src/components/Gallery.js
+++ b/examples/src/components/Gallery.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { css, StyleSheet } from 'aphrodite/no-important';
 import Lightbox from 'react-images';
+import ScrollLock from 'react-scrolllock';
 
 class Gallery extends Component {
 	constructor () {
@@ -77,6 +78,7 @@ class Gallery extends Component {
 		);
 	}
 	render () {
+	    if (this.state.lightboxIsOpen){
 		return (
 			<div className="section">
 				{this.props.heading && <h2>{this.props.heading}</h2>}
@@ -85,7 +87,6 @@ class Gallery extends Component {
 				<Lightbox
 					currentImage={this.state.currentImage}
 					images={this.props.images}
-					isOpen={this.state.lightboxIsOpen}
 					onClickImage={this.handleClickImage}
 					onClickNext={this.gotoNext}
 					onClickPrev={this.gotoPrevious}
@@ -94,8 +95,19 @@ class Gallery extends Component {
 					showThumbnails={this.props.showThumbnails}
 					theme={this.props.theme}
 				/>
+				<ScrollLock/>
 			</div>
 		);
+	    }
+	    else{
+		    return (
+			<div className="section">
+				{this.props.heading && <h2>{this.props.heading}</h2>}
+				{this.props.subheading && <p>{this.props.subheading}</p>}
+				{this.renderGallery()}
+			</div>
+		    );
+	    }
 	}
 }
 

--- a/examples/src/components/Gallery.js
+++ b/examples/src/components/Gallery.js
@@ -78,36 +78,36 @@ class Gallery extends Component {
 		);
 	}
 	render () {
-	    if (this.state.lightboxIsOpen){
-		return (
-			<div className="section">
-				{this.props.heading && <h2>{this.props.heading}</h2>}
-				{this.props.subheading && <p>{this.props.subheading}</p>}
-				{this.renderGallery()}
-				<Lightbox
-					currentImage={this.state.currentImage}
-					images={this.props.images}
-					onClickImage={this.handleClickImage}
-					onClickNext={this.gotoNext}
-					onClickPrev={this.gotoPrevious}
-					onClickThumbnail={this.gotoImage}
-					onClose={this.closeLightbox}
-					showThumbnails={this.props.showThumbnails}
-					theme={this.props.theme}
-				/>
-				<ScrollLock/>
-			</div>
-		);
-	    }
-	    else{
-		    return (
-			<div className="section">
-				{this.props.heading && <h2>{this.props.heading}</h2>}
-				{this.props.subheading && <p>{this.props.subheading}</p>}
-				{this.renderGallery()}
-			</div>
-		    );
-	    }
+		if (this.state.lightboxIsOpen) {
+			return (
+				<div className="section">
+					{this.props.heading && <h2>{this.props.heading}</h2>}
+					{this.props.subheading && <p>{this.props.subheading}</p>}
+					{this.renderGallery()}
+					<Lightbox
+						currentImage={this.state.currentImage}
+						images={this.props.images}
+						onClickImage={this.handleClickImage}
+						onClickNext={this.gotoNext}
+						onClickPrev={this.gotoPrevious}
+						onClickThumbnail={this.gotoImage}
+						onClose={this.closeLightbox}
+						showThumbnails={this.props.showThumbnails}
+						theme={this.props.theme}
+					/>
+					<ScrollLock/>
+				</div>
+			);
+		}
+		else {
+			return (
+				<div className="section">
+					{this.props.heading && <h2>{this.props.heading}</h2>}
+					{this.props.subheading && <p>{this.props.subheading}</p>}
+					{this.renderGallery()}
+				</div>
+			);
+		}
 	}
 }
 
@@ -171,5 +171,4 @@ const classes = StyleSheet.create({
 		width: 'auto',
 	},
 });
-
 export default Gallery;

--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { css, StyleSheet } from 'aphrodite/no-important';
-import ScrollLock from 'react-scrolllock';
 
 import theme from './theme';
 import Arrow from './components/Arrow';
@@ -29,7 +28,7 @@ class Lightbox extends Component {
 		};
 	}
 	componentDidMount () {
-		if (this.props.isOpen && this.props.enableKeyboardInput) {
+		if (this.props.enableKeyboardInput) {
 			window.addEventListener('keydown', this.handleKeyboardInput);
 		}
 	}
@@ -59,13 +58,6 @@ class Lightbox extends Component {
 			}
 		}
 
-		// add/remove event listeners
-		if (!this.props.isOpen && nextProps.isOpen && nextProps.enableKeyboardInput) {
-			window.addEventListener('keydown', this.handleKeyboardInput);
-		}
-		if (!nextProps.isOpen && nextProps.enableKeyboardInput) {
-			window.removeEventListener('keydown', this.handleKeyboardInput);
-		}
 	}
 	componentWillUnmount () {
 		if (this.props.enableKeyboardInput) {
@@ -157,14 +149,12 @@ class Lightbox extends Component {
 		const {
 			backdropClosesModal,
 			customControls,
-			isOpen,
 			onClose,
 			showCloseButton,
 			showThumbnails,
 			width,
 		} = this.props;
 
-		if (!isOpen) return <span key="closed" />;
 
 		let offsetThumbnails = 0;
 		if (showThumbnails) {
@@ -189,7 +179,6 @@ class Lightbox extends Component {
 				{this.renderThumbnails()}
 				{this.renderArrowPrev()}
 				{this.renderArrowNext()}
-				<ScrollLock />
 			</Container>
 		);
 	}
@@ -285,7 +274,6 @@ Lightbox.propTypes = {
 			thumbnail: PropTypes.string,
 		})
 	).isRequired,
-	isOpen: PropTypes.bool,
 	leftArrowTitle: PropTypes.string,
 	onClickImage: PropTypes.func,
 	onClickNext: PropTypes.func,


### PR DESCRIPTION
**Description of changes:**
-Removal of the isOpen prop from Lightbox.  Is there a reason that Lightbox needs to know whether its open?  Or can't we leave that to the app? The user should be able to control in their app whether or not the Lightbox is showing which will enable them to control more things like adding routing which isn't possible otherwise.  

-Also removing the adding and removing of keyboard events as i don't see how it would change from one photo to the next.

**Related issues (if any):**
breaking change

**Checks:**

- [x] Please confirm `npm run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed
- [x] [if new feature] Please confirm that documentation was added to the README.md
