### PR TITLE
Also accept `srcSet` with capital S

### DIFF
--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -86,6 +86,7 @@ class Lightbox extends Component {
 		const img = new Image();
 
 		img.src = image.src;
+		img.srcset = img.srcSet || img.srcset;
 
 		if (image.srcset) {
 			img.srcset = image.srcset.join();
@@ -212,6 +213,7 @@ class Lightbox extends Component {
 		if (!images || !images.length) return null;
 
 		const image = images[currentImage];
+		image.srcset = image.srcSet || image.srcset;
 
 		let srcset;
 		let sizes;


### PR DESCRIPTION
Because at the end, `srcSet` the correct attribute name:

https://facebook.github.io/react/docs/dom-elements.html#all-supported-html-attributes
