### PR TITLE
fix react and react-dom peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "react": "^16.0.0"
   },
   "peerDependencies": {
-    "react-dom": "^0.15 || ^16.0",
-    "react": "^0.15 || ^16.0"
+    "react-dom": "^15.0 || ^16.0",
+    "react": "^15.0 || ^16.0"
   },
   "browserify-shim": {
     "react": "global:React"


### PR DESCRIPTION
In the peerDependencies there are dependencies to versions of `react` and `react-dom` that don't exist. This PR fixes that.