### PR TITLE
LightBox: allow plain DOM srcSet string

### DIFF
--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -224,7 +224,7 @@ class Lightbox extends Component {
 		let sizes;
 
 		if (image.srcset) {
-			srcset = image.srcset.join();
+			srcset = image.srcset.join ? image.srcset.join() : image.srcset;
 			sizes = '100vw';
 		}
 
@@ -294,6 +294,7 @@ Lightbox.propTypes = {
 	images: PropTypes.arrayOf(
 		PropTypes.shape({
 			src: PropTypes.string.isRequired,
+			srcSet: PropTypes.string,
 			srcset: PropTypes.array,
 			caption: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 			thumbnail: PropTypes.string,


### PR DESCRIPTION
**Description of changes:**

Allow using the normal `srcSet` pre-joined string instead of an array of strings

**Checks:**

- [ ] Please confirm `npm run lint` ran successfully
- [ ] Please confirm that only `/src` and `/examples/src` are committed
- [ ] [if new feature] Please confirm that documentation was added to the README.md

None of the above, untested and refining a previously undocumented feature 😁 