### PR TITLE
Unmount the component tree before removing the portal node from DOM.

### DIFF
--- a/src/components/Portal.js
+++ b/src/components/Portal.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { CSSTransitionGroup } from 'react-transition-group';
-import { render } from 'react-dom';
+import { render, unmountComponentAtNode } from 'react-dom';
 import PassContext from './PassContext';
 
 
@@ -43,6 +43,7 @@ export default class Portal extends Component {
 		);
 	}
 	componentWillUnmount () {
+		unmountComponentAtNode(this.portalElement);
 		document.body.removeChild(this.portalElement);
 	}
 	render () {


### PR DESCRIPTION
**Description of changes:**

Currently the React component tree is not being unmounted when removing the portal node from the dom. As a result these references are kept in memory and keep accumulating when instantiating new galleries.
This PR unmounts the React component tree at the portal node in addition to removing the portal node from the DOM.

**Checks:**

- [ ] Please confirm `npm run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed
