### PR TITLE
Update react-scrolllock to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "aphrodite": "^0.5.0",
     "prop-types": "^15.6.0",
-    "react-scrolllock": "^1.0.5",
+    "react-scrolllock": "^2.0.1",
     "react-spinners": "^0.2.5",
     "react-transition-group": "^1.1.3"
   },


### PR DESCRIPTION
**Description of changes:**

Updates react-scrolllock to ^2.0.1 for React 16 compatibility.

**Related issues (if any):**

Fixes #184

**Checks:**

- [x] Please confirm `npm run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed
- [x] [if new feature] Please confirm that documentation was added to the README.md
