### PR TITLE
Quick fix for "srcSet" inconsistency

### DIFF
--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -109,7 +109,7 @@ class Lightbox extends Component {
 		img.src = image.src;
 		img.srcSet = image.srcSet || image.srcset;
 
-		if (img.srcSet) img.setAttribute('srcset', img.srcSet);
+		if (img.srcSet) img.setAttribute('srcset', img.srcSet.join(',\n'));
 
 		return img;
 	}


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

**Description of changes:**
Correct assignment of the `srcset` attribute to `img` elements.

**Related issues (if any):**
#203

**Checks:**

- [x] Please confirm `yarn run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed
