### PR TITLE
Fix #206: load image if isOpen is set

### DIFF
--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -42,7 +42,7 @@ class Lightbox extends Component {
 			if (this.props.enableKeyboardInput) {
 				window.addEventListener('keydown', this.handleKeyboardInput);
 			}
-			if (this.props.currentImage) {
+			if (typeof this.props.currentImage === 'number') {
 				this.preloadImage(this.props.currentImage, this.handleImageLoaded);
 			}
 		}


### PR DESCRIPTION
**Description of changes:**

This PR fixes infinite loading when `isOpen` is set.

**Related issues (if any):**

#206 

**Checks:**

- [x] Please confirm `yarn run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed
- [x] [if new feature] Please confirm that documentation was added to the README.md
