### PR TITLE
Fix Lightbox srcSet prop type validation

### DIFF
--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -375,7 +375,7 @@ Lightbox.propTypes = {
 	images: PropTypes.arrayOf(
 		PropTypes.shape({
 			src: PropTypes.string.isRequired,
-			srcSet: PropTypes.array,
+			srcSet: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
 			caption: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 			thumbnail: PropTypes.string,
 		})

--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -375,7 +375,7 @@ Lightbox.propTypes = {
 	images: PropTypes.arrayOf(
 		PropTypes.shape({
 			src: PropTypes.string.isRequired,
-			srcSet: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+			srcSet: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
 			caption: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 			thumbnail: PropTypes.string,
 		})


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

**Description of changes:**

Fix Lightbox srcSet prop type validation

**Related issues (if any):**

#203

**Checks:**

- [x] Please confirm `yarn run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed
