### PR TITLE
Updated the width prop to include more valid CSS values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ preloadNextImage | bool | true | Based on the direction the user is navigating, 
 rightArrowTitle | string | ' Next (Right arrow key) ' | Customize right arrow title
 showCloseButton | bool  | true | Optionally display a close "X" button in top right corner
 showImageCount | bool  | true | Optionally display image index, e.g., "3 of 20"
-width | number  | 1024 | Maximum width of the carousel; defaults to 1024px
+width | number\|string | 1024 | Maximum width of the carousel; defaults to 1024px. Accepts values as `px`, `vw`, `%`, `none`, `initial` or `inherit`. A plain number defaults to usage in `px`.
 spinner | func | DefaultSpinner | Spinner component class
 spinnerColor | string | 'white' | Color of spinner
 spinnerSize | number | 100 | Size of spinner

--- a/examples/src/index.html
+++ b/examples/src/index.html
@@ -197,9 +197,9 @@
 										</tr>
 										<tr>
 											<td align="left">width</td>
-											<td align="left">number</td>
+											<td align="left">number|string</td>
 											<td align="left">1024</td>
-											<td align="left">Maximum width of the carousel; defaults to 1024px</td>
+											<td align="left">Maximum width of the carousel; defaults to 1024px. Accepts values as <code>px</code>, <code>vw</code>, <code>%</code>, <code>none</code>, <code>initial</code> or <code>inherit</code>. A plain number defaults to usage in <code>px</code>.</td>
 										</tr>
 									</tbody>
 								</table>

--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -397,7 +397,14 @@ Lightbox.propTypes = {
 	spinnerSize: PropTypes.number,
 	theme: PropTypes.object,
 	thumbnailOffset: PropTypes.number,
-	width: PropTypes.number,
+	width: function (props, propName, componentName) {
+		if (!/^\d+(px|%|vw|$)|initial|inherit|none/.test(props[propName])) {
+			return new Error(
+                                'Invalid prop `' + propName + '` supplied to `' + componentName + '`. '
+                                + 'Valid values are `initial`, `inherit`, `none` or a number as `px`, `vw` or `%`.'
+			);
+		}
+	},
 };
 Lightbox.defaultProps = {
 	closeButtonTitle: 'Close (Esc)',


### PR DESCRIPTION
**Description of changes:**
Enhances the `width` prop of the lightbox component. After this commit, the property accepts the width value as a plain number, numbers with a `px`, `vw` or `%` suffix, `none`, `inherit` and `initial`.

**Related issues (if any):**
Fixes #165

**Checks:**

- [x] Please confirm `yarn run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed
- [x] [if new feature] Please confirm that documentation was added to the README.md
