### PR TITLE
add zindex to close button to bring it in front of spinner

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -56,6 +56,7 @@ const defaultStyles = {
 		position: 'relative',
 		top: 0,
 		verticalAlign: 'bottom',
+		zIndex: 1,
 
 		// increase hit area
 		height: 40,


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

**Description of changes:**
adds z-index: 1 to close button in order to bring close in front of spinner.

**Related issues (if any):**
closes #224 

**Checks:**

- [x] Please confirm `yarn run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed
- [x] [if new feature] Please confirm that documentation was added to the README.md
