### PR TITLE
LightBox srcSet support for string and array

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ const LIGHTBOX_IMAGE_SET = [
   {
     src: 'http://example.com/example/img1.jpg',
     caption: 'A forest'
+    // As an array
     srcSet: [
       'http://example.com/example/img1_1024.jpg 1024w',
       'http://example.com/example/img1_800.jpg 800w',
@@ -73,12 +74,8 @@ const LIGHTBOX_IMAGE_SET = [
   },
   {
     src: 'http://example.com/example/img2.jpg',
-    srcSet: [
-      'http://example.com/example/img2_1024.jpg 1024w',
-      'http://example.com/example/img2_800.jpg 800w',
-      'http://example.com/example/img2_500.jpg 500w',
-      'http://example.com/example/img2_320.jpg 320w',
-    ],
+    // As a string
+    srcSet: 'http://example.com/example/img2_1024.jpg 1024w, http://example.com/example/img2_800.jpg 800w, http://example.com/example/img2_500.jpg 500w, http://example.com/example/img2_320.jpg 320w',
   }
 ];
 
@@ -117,6 +114,6 @@ preventScroll | bool | true | Determines whether scrolling is prevented via [rea
 Property	|	Type		|	Default		|	Description
 :-----------------------|:--------------|:--------------|:--------------------------------
 src  | string | undefined | Required
-srcSet  | array of strings | undefined | Optional
+srcSet  | array of strings or string | undefined | Optional
 caption  | string | undefined | Optional
 alt  | string | undefined | Optional

--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -375,7 +375,7 @@ Lightbox.propTypes = {
 	images: PropTypes.arrayOf(
 		PropTypes.shape({
 			src: PropTypes.string.isRequired,
-			srcSet: PropTypes.array,
+			srcSet: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
 			caption: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 			thumbnail: PropTypes.string,
 		})


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

**Description of changes:**
Support for `string` and `array` in the `Lightbox` property `srcSet`

**Related issues (if any):**
https://github.com/jossmac/react-images/issues/235
**Checks:**

- [x] Please confirm `yarn run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed
- [x] [if new feature] Please confirm that documentation was added to the README.md
