### PR TITLE
Fix #240: Spinner consumes pointer events

### DIFF
--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -455,6 +455,7 @@ const defaultStyles = {
 		// opacity animation to make spinner appear with delay
 		opacity: 0,
 		transition: 'opacity 0.3s',
+		pointerEvents: 'none',
 	},
 	spinnerActive: {
 		opacity: 1,


### PR DESCRIPTION
The spinner visibility is controlled via opacity, so it
will still consume mouse events when hidden. 

**Description of changes:**
Sets spinner target to not receive pointer-events.

**Related issues (if any):**
#240 

**Checks:**

- [x] Please confirm `yarn run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed
- [ ] [if new feature] Please confirm that documentation was added to the README.md
