### PR TITLE
Stopping propagation when click backdrops

### DIFF
--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -152,10 +152,10 @@ class Lightbox extends Component {
 		this.props.onClickPrev();
 	}
 	closeBackdrop (event) {
-    if (event) {
+		if (event) {
 			event.preventDefault();
 			event.stopPropagation();
-    }
+		}
 
 		// make sure event only happens if they click the backdrop
 		// and if the caption is widening the figure element let that respond too

--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -152,14 +152,11 @@ class Lightbox extends Component {
 		this.props.onClickPrev();
 	}
 	closeBackdrop (event) {
-		if (event) {
-			event.preventDefault();
-			event.stopPropagation();
-		}
-
 		// make sure event only happens if they click the backdrop
 		// and if the caption is widening the figure element let that respond too
 		if (event.target.id === 'lightboxBackdrop' || event.target.tagName === 'FIGURE') {
+			event.preventDefault();
+			event.stopPropagation();
 			this.props.onClose();
 		}
 	}

--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -152,6 +152,11 @@ class Lightbox extends Component {
 		this.props.onClickPrev();
 	}
 	closeBackdrop (event) {
+    if (event) {
+			event.preventDefault();
+			event.stopPropagation();
+    }
+
 		// make sure event only happens if they click the backdrop
 		// and if the caption is widening the figure element let that respond too
 		if (event.target.id === 'lightboxBackdrop' || event.target.tagName === 'FIGURE') {


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

**Description of changes:**
In closeBackdrop method, Added stopPropagation(), and preventDefault() to prevent click though the backdrop in MOBILE view.

**Related issues (if any):**


**Checks:**

- [x] Please confirm `yarn run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed
- [ ] [if new feature] Please confirm that documentation was added to the README.md
