### PR TITLE
fix duplicated install commands in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A mobile-friendly, highly customizable, carousel component for displaying media 
 Start by installing `react-images`
 
 ```bash
-yarn add react-images
+npm add react-images
 ```
 or
 ```bash

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A mobile-friendly, highly customizable, carousel component for displaying media 
 Start by installing `react-images`
 
 ```bash
-npm add react-images
+npm install react-images
 ```
 or
 ```bash


### PR DESCRIPTION
**Description of changes:**
I noticed that `yarn install react-images` was duplicated in the readme, and assumed that one of the commands should have been `npm install react-images`. If that was not an error, but rather a subtle joke, then I apologize :)
