### PR TITLE
Fixed IE11 format bug

### DIFF
--- a/src/components/Modal/styled.js
+++ b/src/components/Modal/styled.js
@@ -84,7 +84,9 @@ type DialogProps = DialogState &
     innerProps: Object, // TODO
   };
 
-export const dialogCSS = () => ({});
+export const dialogCSS = () => ({
+  width: '100%'
+});
 
 export const Dialog = (props: DialogProps) => {
   const { children, getStyles, innerProps, isFullscreen } = props;

--- a/src/components/View.js
+++ b/src/components/View.js
@@ -38,7 +38,7 @@ const View = (props: Props) => {
         css={{
           height: 'auto',
           maxHeight: '100vh',
-          maxWidth: '100%',
+          maxWidth: '100vw',
           userSelect: 'none',
         }}
       />


### PR DESCRIPTION
Fixed formatting issues that made the modal and carousel unusable in Internet Explorer 11
Fixes issue #304 

**Tested on**

- Windows 10 1903
  - Chrome 75
  - Internet Explorer 11
  - Firefox 67

- iOS 12.3.1
  - Safari 

- Android 9
  - Firefox 68
  - Chrome 75

**Checks:**

- [x] Please confirm `yarn run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed

