### PR TITLE
Fix inability to close modal on click on backdrop

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -104,7 +104,7 @@ class Modal extends Component<Props, State> {
   handleBackdropClick = (event: MouseEvent) => {
     const { closeOnBackdropClick } = this.props;
 
-    if (!event.target.classList.contains(className('view')) || !closeOnBackdropClick) return;
+    if ( closeOnBackdropClick || event.target.classList.contains(className('view')) ) return;
 
     this.handleClose(event);
   };


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

**Description of changes:**
This change fixes an issue where clicking on the modal backdrop would not close the modal properly.

**Related issues (if any):**
https://github.com/jossmac/react-images/issues/302

**Checks:**

- [x] Please confirm `yarn run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed
- [ ] [if new feature] Please confirm that documentation was added to the README.md
