### PR TITLE
docs: updates for NPM link

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,13 @@
   "jsnext:main": "dist/react-images.es.js",
   "module": "dist/react-images.es.js",
   "author": "Joss Mackison",
+  "repository": {
+    "url": "https://github.com/jossmac/react-images"
+  },
+  "bugs": {
+    "url": "https://github.com/jossmac/react-images/issues"
+  },
+  "homepage": "https://jossmac.github.io/react-images/",
   "license": "MIT",
   "keywords": [
     "react",


### PR DESCRIPTION
by adding repository and homepage tags might help user to directly jump to examples / github repo
https://www.npmjs.com/package/react-images

<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

**Description of changes:**


**Related issues (if any):**


**Checks:**

- [x] Please confirm `yarn run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed
- [x] [if new feature] Please confirm that documentation was added to the README.md
