### PR TITLE
feat(carousel): introduce hideNavigationOnTouchDevice prop

### DIFF
--- a/docs/pages/Home/props.js
+++ b/docs/pages/Home/props.js
@@ -104,6 +104,14 @@ type components = {
     type: 'Number | false',
   },
   {
+    defaultValue: 'true',
+    description:
+      'Whether the navigation should be hidden or visible on touch devices',
+    isRequired: false,
+    name: 'hideNavigationOnTouchDevice',
+    type: 'boolean',
+  },
+  {
     defaultValue: null,
     description:
       'Available when the Carousel is within a Modal. The applicable props are cloned and passed on for use inside Carousel components.',

--- a/docs/pages/Home/props.js
+++ b/docs/pages/Home/props.js
@@ -104,14 +104,6 @@ type components = {
     type: 'Number | false',
   },
   {
-    defaultValue: 'true',
-    description:
-      'Whether the navigation should be hidden or visible on touch devices',
-    isRequired: false,
-    name: 'hideNavigationOnTouchDevice',
-    type: 'boolean',
-  },
-  {
     defaultValue: null,
     description:
       'Available when the Carousel is within a Modal. The applicable props are cloned and passed on for use inside Carousel components.',

--- a/docs/pages/Home/props.js
+++ b/docs/pages/Home/props.js
@@ -126,6 +126,14 @@ type components = {
 }`,
   },
   {
+    defaultValue: 'false',
+    description:
+      'Whether image carousel navigation buttons should be hidden or shown on touch-enabled devices. (Default: hidden)',
+    isRequired: false,
+    name: 'showNavigationOnTouchDevice',
+    type: 'boolean',
+  },
+  {
     defaultValue: null,
     description:
       'React-Images ships each Carousel component with default styles. You can extend or replace these using the styles property.',

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -39,7 +39,7 @@ export type CarouselProps = {
   /* Duration, in milliseconds, to wait before hiding controls when the user is idle */
   hideControlsWhenIdle?: number | false,
   /* Force hide or show controls on touch devices */
-  hideNavigationOnTouchDevice?: boolean,
+  showNavigationOnTouchDevice?: boolean,
   /* When envoked within a modal, props are cloned from the modal */
   modalProps?: ModalProps,
   /* Style modifier methods */
@@ -79,7 +79,7 @@ const defaultProps = {
   currentIndex: 0,
   formatters,
   hideControlsWhenIdle: 3000,
-  hideNavigationOnTouchDevice: true,
+  showNavigationOnTouchDevice: false,
   styles: {},
   trackProps: {
     instant: !isTouch(),
@@ -333,7 +333,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
   };
 
   getCommonProps() {
-    const { frameProps, trackProps, modalProps, views, hideNavigationOnTouchDevice } = this.props;
+    const { frameProps, trackProps, modalProps, views, showNavigationOnTouchDevice } = this.props;
     const isModal = Boolean(modalProps);
     const isFullscreen = Boolean(modalProps && modalProps.isFullscreen);
     const { currentIndex, interactionIsIdle } = this.state;
@@ -346,7 +346,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
       formatters: this.props.formatters,
       frameProps,
       getStyles: this.getStyles,
-      hideNavigationOnTouchDevice,
+      showNavigationOnTouchDevice,
       isFullscreen,
       isModal,
       modalProps,

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -38,6 +38,8 @@ export type CarouselProps = {
   formatters: typeof formatters,
   /* Duration, in milliseconds, to wait before hiding controls when the user is idle */
   hideControlsWhenIdle?: number | false,
+  /* Force hide or show controls on touch devices */
+  hideNavigationOnTouchDevice?: boolean,
   /* When envoked within a modal, props are cloned from the modal */
   modalProps?: ModalProps,
   /* Style modifier methods */
@@ -77,6 +79,7 @@ const defaultProps = {
   currentIndex: 0,
   formatters,
   hideControlsWhenIdle: 3000,
+  hideNavigationOnTouchDevice: true,
   styles: {},
   trackProps: {
     instant: !isTouch(),
@@ -330,7 +333,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
   };
 
   getCommonProps() {
-    const { frameProps, trackProps, modalProps, views } = this.props;
+    const { frameProps, trackProps, modalProps, views, hideNavigationOnTouchDevice } = this.props;
     const isModal = Boolean(modalProps);
     const isFullscreen = Boolean(modalProps && modalProps.isFullscreen);
     const { currentIndex, interactionIsIdle } = this.state;
@@ -343,6 +346,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
       formatters: this.props.formatters,
       frameProps,
       getStyles: this.getStyles,
+      hideNavigationOnTouchDevice,
       isFullscreen,
       isModal,
       modalProps,

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -29,8 +29,8 @@ export const navigationCSS = ({ interactionIsIdle }: NavState) => ({
 });
 
 export const Navigation = (props: NavProps) => {
-  const { children, getStyles, isFullscreen, isModal } = props;
-  return !isTouch() ? (
+  const { children, getStyles, isFullscreen, isModal, hideNavigationOnTouchDevice } = props;
+  return !isTouch() || !hideNavigationOnTouchDevice ? (
     <Nav
       css={getStyles('navigation', props)}
       className={className('navigation', { isFullscreen, isModal })}

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -29,8 +29,8 @@ export const navigationCSS = ({ interactionIsIdle }: NavState) => ({
 });
 
 export const Navigation = (props: NavProps) => {
-  const { children, getStyles, isFullscreen, isModal, hideNavigationOnTouchDevice } = props;
-  return !isTouch() || !hideNavigationOnTouchDevice ? (
+  const { children, getStyles, isFullscreen, isModal, showNavigationOnTouchDevice } = props;
+  return !isTouch() || (isTouch() && showNavigationOnTouchDevice) ? (
     <Nav
       css={getStyles('navigation', props)}
       className={className('navigation', { isFullscreen, isModal })}


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

**Description of changes:**
This prop will allow the users of `react-images` to enable the navigation on touch devices.

**Related issues (if any):**
https://github.com/jossmac/react-images/issues/335

**Checks:**

- [x] Please confirm `yarn run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed
- [x] [if new feature] Please confirm that documentation was added to the README.md
