### PR TITLE
Fix #302 closeOnBackdropClick condition in handleBackdropClick not wo…

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -105,7 +105,7 @@ class Modal extends Component<Props, State> {
     const { closeOnBackdropClick } = this.props;
 
     if (
-      !event.target.classList.contains(className('view')) ||
+      event.target.classList.contains(className('view')) ||
       !closeOnBackdropClick
     )
       {return;}


### PR DESCRIPTION
Description of changes:

Change the judgment condition of the function to make modal close normally

Related issues (if any): #302


**Checks:**

- [x] Please confirm `yarn run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed
- [x] [if new feature] Please confirm that documentation was added to the README.md
