### PR TITLE
fix: currentIndex prop not working correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "dist",
     "lib",
     "src",
-    "./index.d.ts"
+    "index.d.ts"
   ],
   "lint-staged": {
     "*.js": "eslint"

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -132,7 +132,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
     }
 
     if (this.props.currentIndex !== prevProps.currentIndex) {
-      this.setState({ currentIndex: prevProps.currentIndex });
+      this.setState({ currentIndex: this.props.currentIndex });
     }
   }
   componentWillUnmount() {


### PR DESCRIPTION
**Description of changes:**

This PR fixes the bug with `currentIndex` prop. In the `componentDidUpdate` method of `Carousel` component previous and current `currentIndex` props were compared, but the previous `currentIndex` was saved to the state. 
_( Real life scenario: we start with `currentIndex` equal to `0`, update it to `1` - Carousel still renders index `0`, update it to `2` - Carousel renders index `1` )_

Please note, that it's the same case for caching components, however I'm not sure if that's also a bug or not, as I didn't investigate into that.

Also included in this PR is a quick change in `package.json` that causes types to be correctly bundled.

**Related issues (if any):**

- https://github.com/jossmac/react-images/issues/345

**Checks:**

- [x] Please confirm `yarn run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed _//package.json is also affected ( on purpose )_
- [ ] [if new feature] Please confirm that documentation was added to the README.md
