### PR TITLE
Made clicking on more parts of the backdrop dismiss modal

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -18,6 +18,7 @@ import { type ModalProps } from './Modal/Modal';
 import { className, isTouch } from '../utils';
 import formatters from '../formatters';
 import { type ViewsType } from '../types';
+import componentBaseClassNames from './componentBaseClassNames';
 
 type SpringConfig = { [key: string]: number };
 export type fn = any => void;
@@ -87,14 +88,7 @@ const defaultProps = {
   },
 };
 
-/**
- * Used to get the className to select the track (area above and below the
- * carousel) in other components.
- * 
- * This className is we call `className()` in utils with to get the full
- * className.
- */
-export const trackBaseClassName = 'track';
+export const trackBaseClassName = componentBaseClassNames.Track;
 
 class Carousel extends Component<CarouselProps, CarouselState> {
   commonProps: any; // TODO

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -87,6 +87,15 @@ const defaultProps = {
   },
 };
 
+/**
+ * Used to get the className to select the track (area above and below the
+ * carousel) in other components.
+ * 
+ * This className is we call `className()` in utils with to get the full
+ * className.
+ */
+export const trackBaseClassName = 'track';
+
 class Carousel extends Component<CarouselProps, CarouselState> {
   commonProps: any; // TODO
   components: CarouselComponents;
@@ -381,7 +390,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
               {...this.getTrackProps(this.props)}
               style={{ display: 'flex', alignItems: 'center' }}
               currentView={currentIndex}
-              className={className('track')}
+              className={className(trackBaseClassName)}
               onViewChange={this.handleViewChange}
               ref={this.getTrack}
             >

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -88,7 +88,7 @@ const defaultProps = {
   },
 };
 
-export const trackBaseClassName = componentBaseClassNames.Track;
+const trackBaseClassName = componentBaseClassNames.Track;
 
 class Carousel extends Component<CarouselProps, CarouselState> {
   commonProps: any; // TODO

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -42,6 +42,13 @@ export const footerCSS = ({ isModal, interactionIsIdle }: State) => ({
   },
 });
 
+/**
+ * Used to get the className to select the footer in other components.
+ * This className is we call `className()` in utils with to get the full
+ * className.
+ */
+export const footerBaseClassName = 'footer';
+
 const Footer = (props: Props) => {
   const { components, getStyles, innerProps, isFullscreen, isModal } = props;
 
@@ -51,12 +58,12 @@ const Footer = (props: Props) => {
 
   const state = { isFullscreen, isModal };
   const cn = {
-    container: className('footer', state),
+    container: className(footerBaseClassName, state),
     caption: className('footer__caption', state),
     count: className('footer__count', state),
   };
   const css = {
-    container: getStyles('footer', props),
+    container: getStyles(footerBaseClassName, props),
     caption: getStyles('footerCaption', props),
     count: getStyles('footerCount', props),
   };

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -7,6 +7,7 @@ import { smallDevice } from './css-helpers';
 import { Div, Span } from '../primitives';
 import type { PropsWithStyles, ViewType } from '../types';
 import { className } from '../utils';
+import componentBaseClassNames from './componentBaseClassNames';
 
 type State = { isModal: boolean, interactionIsIdle: boolean };
 type Props = State &
@@ -42,12 +43,7 @@ export const footerCSS = ({ isModal, interactionIsIdle }: State) => ({
   },
 });
 
-/**
- * Used to get the className to select the footer in other components.
- * This className is we call `className()` in utils with to get the full
- * className.
- */
-export const footerBaseClassName = 'footer';
+const footerBaseClassName = componentBaseClassNames.Footer;
 
 const Footer = (props: Props) => {
   const { components, getStyles, innerProps, isFullscreen, isModal } = props;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -37,7 +37,7 @@ export const headerCSS = ({ interactionIsIdle }: State) => ({
   zIndex: 1,
 });
 
-export const headerBaseClassName = componentBaseClassNames.Header;
+const headerBaseClassName = componentBaseClassNames.Header;
 
 const Header = (props: Props) => {
   const {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -36,6 +36,13 @@ export const headerCSS = ({ interactionIsIdle }: State) => ({
   zIndex: 1,
 });
 
+/**
+ * Used to get the className to select the header in other components.
+ * This className is we call `className()` in utils with to get the full
+ * className.
+ */
+export const headerBaseClassName = 'header';
+
 const Header = (props: Props) => {
   const {
     components,
@@ -61,8 +68,8 @@ const Header = (props: Props) => {
 
   return (
     <Div
-      css={getStyles('header', props)}
-      className={className('header', state)}
+      css={getStyles(headerBaseClassName, props)}
+      className={className(headerBaseClassName, state)}
       // TODO glam prefixer fails on gradients
       // https://github.com/threepointone/glam/issues/35
       style={{

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -7,6 +7,7 @@ import { Button, Div } from '../primitives';
 import { className } from '../utils';
 import type { PropsWithStyles } from '../types';
 import { Close, FullscreenEnter, FullscreenExit } from './svg';
+import componentBaseClassNames from './componentBaseClassNames';
 
 type State = { interactionIsIdle: boolean };
 type Props = PropsWithStyles &
@@ -36,12 +37,7 @@ export const headerCSS = ({ interactionIsIdle }: State) => ({
   zIndex: 1,
 });
 
-/**
- * Used to get the className to select the header in other components.
- * This className is we call `className()` in utils with to get the full
- * className.
- */
-export const headerBaseClassName = 'header';
+export const headerBaseClassName = componentBaseClassNames.Header;
 
 const Header = (props: Props) => {
   const {

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -120,9 +120,12 @@ class Modal extends Component<Props, State> {
     if (allowClose) this.handleClose(event);
   };
   handleBackdropClick = (event: MouseEvent) => {
-    const hasBackdropClassName = event.target.classList.some(className =>
-      backdropClassNames.has(className),
-    );
+    let hasBackdropClassName = false;
+    for (const targetClass of event.target.classList) {
+      if (backdropClassNames.has(targetClass)) {
+        hasBackdropClassName = true;
+      }
+    }
 
     if (!hasBackdropClassName || !this.props.closeOnBackdropClick) {
       return;

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -10,9 +10,12 @@ import {
   type ModalComponents,
 } from '../defaultComponents';
 import { Fade, SlideUp } from './Animation';
-import { type CarouselType } from '../Carousel';
+import { type CarouselType, trackBaseClassName } from '../Carousel';
 import { defaultModalStyles, type ModalStylesConfig } from '../../styles';
 import { isTouch, className } from '../../utils';
+import { headerBaseClassName } from '../Header';
+import { footerBaseClassName } from '../Footer';
+import { viewBaseClassName } from '../View';
 
 type MouseOrKeyboardEvent = MouseEvent | KeyboardEvent;
 export type CloseType = (event: MouseOrKeyboardEvent) => void;
@@ -55,6 +58,17 @@ const defaultProps = {
   preventScroll: true,
   styles: {},
 };
+
+/** Classes that when clicked on, close the backdrop */
+const backdropClassNames = new Set(
+  [
+    viewBaseClassName,
+    headerBaseClassName,
+    footerBaseClassName,
+    trackBaseClassName,
+  ].map(className),
+);
+
 class Modal extends Component<Props, State> {
   commonProps: any; // TODO
   components: ModalComponents;
@@ -106,10 +120,11 @@ class Modal extends Component<Props, State> {
     if (allowClose) this.handleClose(event);
   };
   handleBackdropClick = (event: MouseEvent) => {
-    if (
-      !event.target.classList.contains(className('view')) ||
-      !this.props.closeOnBackdropClick
-    ) {
+    const hasBackdropClassName = event.target.classList.some(className =>
+      backdropClassNames.has(className),
+    );
+
+    if (!hasBackdropClassName || !this.props.closeOnBackdropClick) {
       return;
     }
 

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -10,12 +10,10 @@ import {
   type ModalComponents,
 } from '../defaultComponents';
 import { Fade, SlideUp } from './Animation';
-import { type CarouselType, trackBaseClassName } from '../Carousel';
+import { type CarouselType } from '../Carousel';
 import { defaultModalStyles, type ModalStylesConfig } from '../../styles';
 import { isTouch, className } from '../../utils';
-import { headerBaseClassName } from '../Header';
-import { footerBaseClassName } from '../Footer';
-import { viewBaseClassName } from '../View';
+import componentBaseClassNames from '../componentBaseClassNames';
 
 type MouseOrKeyboardEvent = MouseEvent | KeyboardEvent;
 export type CloseType = (event: MouseOrKeyboardEvent) => void;
@@ -62,10 +60,10 @@ const defaultProps = {
 /** Classes that when clicked on, close the backdrop */
 const backdropClassNames = new Set(
   [
-    viewBaseClassName,
-    headerBaseClassName,
-    footerBaseClassName,
-    trackBaseClassName,
+    componentBaseClassNames.View,
+    componentBaseClassNames.Header,
+    componentBaseClassNames.Footer,
+    componentBaseClassNames.Track,
   ].map(className),
 );
 

--- a/src/components/View.js
+++ b/src/components/View.js
@@ -20,6 +20,13 @@ export const viewCSS = () => ({
   textAlign: 'center',
 });
 
+/**
+ * Used to get the className to select the view in other components.
+ * This className is we call `className()` in utils with to get the full
+ * className.
+ */
+export const viewBaseClassName = 'view';
+
 const View = (props: Props) => {
   const { data, formatters, getStyles, index, isFullscreen, isModal } = props;
   const innerProps = {
@@ -29,8 +36,8 @@ const View = (props: Props) => {
 
   return (
     <Div
-      css={getStyles('view', props)}
-      className={className('view', { isFullscreen, isModal })}
+      css={getStyles(viewBaseClassName, props)}
+      className={className(viewBaseClassName, { isFullscreen, isModal })}
     >
       <Img
         {...innerProps}

--- a/src/components/View.js
+++ b/src/components/View.js
@@ -7,6 +7,7 @@ import { Div, Img } from '../primitives';
 import { type PropsWithStyles } from '../types';
 import { className } from '../utils';
 import { getSource } from './component-helpers';
+import componentBaseClassNames from './componentBaseClassNames';
 
 type Props = PropsWithStyles & {
   data: Object,
@@ -20,12 +21,7 @@ export const viewCSS = () => ({
   textAlign: 'center',
 });
 
-/**
- * Used to get the className to select the view in other components.
- * This className is we call `className()` in utils with to get the full
- * className.
- */
-export const viewBaseClassName = 'view';
+export const viewBaseClassName = componentBaseClassNames.View;
 
 const View = (props: Props) => {
   const { data, formatters, getStyles, index, isFullscreen, isModal } = props;

--- a/src/components/View.js
+++ b/src/components/View.js
@@ -21,7 +21,7 @@ export const viewCSS = () => ({
   textAlign: 'center',
 });
 
-export const viewBaseClassName = componentBaseClassNames.View;
+const viewBaseClassName = componentBaseClassNames.View;
 
 const View = (props: Props) => {
   const { data, formatters, getStyles, index, isFullscreen, isModal } = props;

--- a/src/components/componentBaseClassNames.js
+++ b/src/components/componentBaseClassNames.js
@@ -1,0 +1,13 @@
+/**
+ * Used to get the HTML class to select specific components.
+ * We call `className()` in utils with each of these to get the full className,
+ * with prefixes.
+ */
+const componentBaseClassNames = {
+  Header: 'header',
+  Footer: 'footer',
+  View: 'view',
+  Track: 'track',
+};
+
+export default componentBaseClassNames;


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

**Description of changes:**

Previously, clicking on the header, the footer, or any part of the "track" above or below the image failed to dismiss the modal.

**Related issues (if any):**
 
Pull request #313: another attempt at this that relied on a blacklist rather than a whitelist. I think a whitelist is still safer, as it won't make other buttons unclickable and still leaves text in the caption selectable
Fixes #351

**Checks:**

- [X] Please confirm `yarn run lint` ran successfully
- [X] Please confirm that only `/src` and `/examples/src` are committed
- [ ] [if new feature] Please confirm that documentation was added to the README.md

Also manually tested to verify the change:

- Clicking full-screen, close, and selecting text in footer all work
- Clicking on backdrop above/below, in header area, and footer area all dismiss the modal

![After](https://user-images.githubusercontent.com/2937410/77193789-0801ce80-6a9c-11ea-958d-0b85ac6287f1.gif)
