### PR TITLE
fix readme example src to source

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ component and then use it in the render function.
 import React from 'react';
 import Carousel from 'react-images';
 
-const images = [{ src: 'path/to/image-1.jpg' }, { src: 'path/to/image-2.jpg' }];
+const images = [{ source: 'path/to/image-1.jpg' }, { source: 'path/to/image-2.jpg' }];
 
 class Component extends React.Component {
   render() {
@@ -48,7 +48,7 @@ end of your `<body />` tag.
 import React from 'react';
 import Carousel, { Modal, ModalGateway } from 'react-images';
 
-const images = [{ src: 'path/to/image-1.jpg' }, { src: 'path/to/image-2.jpg' }];
+const images = [{ source: 'path/to/image-1.jpg' }, { source: 'path/to/image-2.jpg' }];
 
 class Component extends React.Component {
   state = { modalIsOpen: false };


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

**Description of changes:**
 
The argument of ViewType is source, but it is src in README example.

**Related issues (if any):**


**Checks:**

- [x] Please confirm `yarn run lint` ran successfully
- [ ] Please confirm that only `/src` and `/examples/src` are committed -> readme...
- [ ] [if new feature] Please confirm that documentation was added to the README.md -> readme...
