### PR TITLE
fix: a syntax error in the styles docs

### DIFF
--- a/docs/pages/CustomStyles/index.js
+++ b/docs/pages/CustomStyles/index.js
@@ -100,7 +100,7 @@ function styleFn(base, state) {
     // none of react-images styles are passed to <View />
     height: 400,
     width: 600,
-  })
+  }),
   footer: (base, state) => {
     const opacity = state.interactionIsIdle ? 0 : 1;
     const transition = 'opacity 300ms';


### PR DESCRIPTION
A comma was missing in the "base and state" section of the styles page.


**Description of changes:**
Added a comma into the code example of the "base and state" section of the styles page.

