### PR TITLE
Fix ViewType caption type to not include react elements

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,7 +33,7 @@ export interface TrackProps {
   onSwipeStart?: () => void;
   onViewChange?: (view: number) => void;
   springConfig?: { [key: string]: number };
-  swipe?: boolean| 'mouse' | 'touch';
+  swipe?: boolean | 'mouse' | 'touch';
   swipeThreshold?: number;
   tag?: any;
   viewsToMove?: number;
@@ -41,7 +41,7 @@ export interface TrackProps {
 }
 
 export interface ViewType {
-  caption?: string | number | null | undefined;
+  caption?: React.ReactNode;
   source: string | {
     download?: string;
     fullscreen?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,7 +41,7 @@ export interface TrackProps {
 }
 
 export interface ViewType {
-  caption?: React.ReactNode;
+  caption?: string | number | null | undefined;
   source: string | {
     download?: string;
     fullscreen?: string;

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -102,7 +102,13 @@ export const FooterCaption = (props: ViewType) => {
       css={getStyles('footerCaption', props)}
       className={className('footer__caption', state)}
     >
-      {ParseHtml(`<span>${caption}</span>`)}
+      {/*
+       * Render a string caption using ParseHtml in case we were passed a
+       * string with HTML. All other types are rendered by JSX by default.
+       */}
+      {caption instanceof string
+        ? ParseHtml(`<span>${caption}</span>`)
+        : caption}
     </Span>
   );
 };


### PR DESCRIPTION

**Description of changes:**
Switches the `caption` type on `ViewType` from `ReactNode`, which includes all the renderable component and fragment types in react, to a subset of renderable primitives, which is what the downstream code actually can handle.

**Related issues (if any):**
Fixes issue #367 

**Checks:**

- [ ] Please confirm `yarn run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed
- [x] [if new feature] Please confirm that documentation was added to the README.md

`yarn run lint` doesn't run successfully, but it also didn't run successfully **before** this commit. No new failures added.