### PR TITLE
fix: typo in docs

### DIFF
--- a/docs/pages/Home/index.js
+++ b/docs/pages/Home/index.js
@@ -57,7 +57,7 @@ class Component extends React.Component {
         <CodeBlock>{`import React from 'react';
 import Carousel, { Modal, ModalGateway } from 'react-images';
 
-const images = [{ src: 'path/to/image-1.jpg' }, { src: 'path/to/image-2.jpg' }];
+const images = [{ source: 'path/to/image-1.jpg' }, { source: 'path/to/image-2.jpg' }];
 
 class Component extends React.Component {
   state = { modalIsOpen: false }


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

**Description of changes:**
Fixes a typo in the **Using The Modal** code example.

As per https://github.com/jossmac/react-images/blob/master/index.d.ts#L45, `src` is not a valid key for `ViewType`.

```ts
Type '{ src: string; }[]' is not assignable to type 'ViewType[]'.
  Property 'source' is missing in type '{ src: string; }' but required in type 'ViewType'.ts(2322)
```

**Checks:**

- [x] Please confirm `yarn run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed
