### PR TITLE
fix(modal): prevent application break when fast double click/escape

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -137,17 +137,19 @@ class Modal extends Component<Props, State> {
   };
   handleClose = (event: MouseOrKeyboardEvent) => {
     const { onClose } = this.props;
-    const { isFullscreen } = this.state;
+    const { isFullscreen, isClosing } = this.state;
 
-    this.setState({ isClosing: true });
+    if (!isClosing) {
+      this.setState({ isClosing: true });
 
-    // force exit fullscreen mode on close
-    if (isFullscreen) {
-      this.toggleFullscreen();
+      // force exit fullscreen mode on close
+      if (isFullscreen) {
+        this.toggleFullscreen();
+      }
+
+      // call the consumer's onClose func
+      onClose(event);
     }
-
-    // call the consumer's onClose func
-    onClose(event);
   };
 
   getStyles = (key: string, props: {}): {} => {


### PR DESCRIPTION
**Description of changes:**
This PR fixes the bug with fast double click on the `escape` or `close` button and prevents the application break.

When you fast double click on the `escape` or `close` button, it tries to close the unmounted component and modal broke.

![double-esc](https://user-images.githubusercontent.com/4295068/84518103-91ddc400-aca6-11ea-86ba-98fac428408b.gif)

**Checks:**

- [x] Please confirm `yarn run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed
- [ ] [if new feature] Please confirm that documentation was added to the README.md
