### PR TITLE
Fix: TypeError: undefined is not an object (evaluating 'handle.active')

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -190,7 +190,7 @@ class Modal extends Component<Props, State> {
     })
 
     return (
-      <FullScreen enabled={isFullscreen} onChange={this.handleFullscreenChange}>
+      <FullScreen handle={{ active: isFullscreen }} onChange={this.handleFullscreenChange}>
         <Fade {...commonProps} component={Blanket} in={transitionIn} />
         <SlideUp
           {...commonProps}


### PR DESCRIPTION
**Description of changes:**

It appears that we're passing a nonexistent `enabled` prop to the FullScreen component. Instead, we should be passing a handle prop consisting of an object with property `active: boolean` (see https://github.com/snakesilk/react-fullscreen/blob/master/src/index.tsx#L11).

This changed in version 0.3.0 of the react-full-screen library: https://github.com/snakesilk/react-fullscreen/commit/bea3a2bebba257c8a76f387094c3a81a7758d676 and regressed with this change in react-images: https://github.com/jossmac/react-images/commit/9fe10bf320d8502e93b6a810dcaf9a283ab059dc

**Related issues (if any):**

Current beta version causes a `TypeError: undefined is not an object (evaluating 'handle.active')`

**Checks:**

- [x] Please confirm `yarn run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed
- ~[ ] [if new feature] Please confirm that documentation was added to the README.md~
