### PR TITLE
Port `react-images` from the unsupported `glam` css-in-js library to `emotion`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,7 @@
         "argsIgnorePattern": "^event$",
         "ignoreRestSiblings": true,
         "vars": "all",
-        "varsIgnorePattern": "^(glam|React)$"
+        "varsIgnorePattern": "^(React)$"
       }
     ],
     "curly": [2, "multi-line"],

--- a/docs/App/components.js
+++ b/docs/App/components.js
@@ -1,8 +1,7 @@
 // @flow
-// @jsx glam
-
-import glam from 'glam'
+/** @jsx jsx */
 import React, { Component, type Node } from 'react'
+import { jsx } from '@emotion/react'
 import { Link, withRouter } from 'react-router-dom'
 import { colors } from '../theme'
 import { smallDevice, largeDevice } from '../utils'

--- a/docs/App/components.js
+++ b/docs/App/components.js
@@ -1,5 +1,5 @@
 // @flow
-/** @jsxRuntime classic *//** @jsxRuntime classic */
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React, { Component, type Node } from 'react'
 import { jsx } from '@emotion/react'

--- a/docs/App/components.js
+++ b/docs/App/components.js
@@ -1,4 +1,5 @@
 // @flow
+/** @jsxRuntime classic *//** @jsxRuntime classic */
 /** @jsx jsx */
 import React, { Component, type Node } from 'react'
 import { jsx } from '@emotion/react'

--- a/docs/App/index.js
+++ b/docs/App/index.js
@@ -1,8 +1,7 @@
 // @flow
-// @jsx glam
-
-import glam from 'glam'
+/** @jsx jsx */
 import React, { Component } from 'react'
+import { jsx } from '@emotion/react'
 import { HashRouter, Route, Switch } from 'react-router-dom'
 import { Helmet } from 'react-helmet'
 

--- a/docs/App/index.js
+++ b/docs/App/index.js
@@ -1,4 +1,5 @@
 // @flow
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React, { Component } from 'react'
 import { jsx } from '@emotion/react'

--- a/docs/ImageProvider.js
+++ b/docs/ImageProvider.js
@@ -91,7 +91,6 @@ export default function withImages(WrappedComponent: ComponentType<*>) {
       fetch(getApiUrl())
         .then(res => res.json())
         .then(data => {
-          console.log('data.results', data.results)
           const images = setData(transformImageData(data.results))
           this.setState({ images, isLoading: false })
         })

--- a/docs/PrettyProps.js
+++ b/docs/PrettyProps.js
@@ -1,8 +1,7 @@
 // @flow
-// @jsx glam
-
-import glam from 'glam'
+/** @jsx jsx */
 import React, { type Node } from 'react'
+import { jsx } from '@emotion/react'
 
 import SyntaxHighlighter, { registerLanguage } from 'react-syntax-highlighter/prism-light'
 import typescript from 'react-syntax-highlighter/languages/prism/typescript'

--- a/docs/PrettyProps.js
+++ b/docs/PrettyProps.js
@@ -1,4 +1,5 @@
 // @flow
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React, { type Node } from 'react'
 import { jsx } from '@emotion/react'

--- a/docs/pages/Accessibility.js
+++ b/docs/pages/Accessibility.js
@@ -1,7 +1,7 @@
 // @flow
-// @jsx glam
-import glam from 'glam'
+/** @jsx jsx */
 import React, { Component } from 'react'
+import { jsx } from '@emotion/react'
 import { Helmet } from 'react-helmet'
 
 import Carousel, { Modal, ModalGateway } from '../../src/components'

--- a/docs/pages/Accessibility.js
+++ b/docs/pages/Accessibility.js
@@ -1,4 +1,5 @@
 // @flow
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React, { Component } from 'react'
 import { jsx } from '@emotion/react'

--- a/docs/pages/CustomComponents/AlternativeMedia/Icon.js
+++ b/docs/pages/CustomComponents/AlternativeMedia/Icon.js
@@ -1,7 +1,7 @@
 // @flow
-// @jsx glam
-import glam from 'glam'
+/** @jsx jsx */
 import React from 'react'
+import { jsx } from '@emotion/react'
 
 type IconProps = { size: number, type: 'play' | 'pause' }
 const Icon = ({ size = 64, type }: IconProps) => {

--- a/docs/pages/CustomComponents/AlternativeMedia/Icon.js
+++ b/docs/pages/CustomComponents/AlternativeMedia/Icon.js
@@ -1,4 +1,5 @@
 // @flow
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React from 'react'
 import { jsx } from '@emotion/react'

--- a/docs/pages/CustomComponents/AlternativeMedia/Poster.js
+++ b/docs/pages/CustomComponents/AlternativeMedia/Poster.js
@@ -1,7 +1,7 @@
 // @flow
-// @jsx glam
-import glam from 'glam'
+/** @jsx jsx */
 import React from 'react'
+import { jsx } from '@emotion/react'
 
 import Icon from './Icon'
 import type { ViewShape } from './View'

--- a/docs/pages/CustomComponents/AlternativeMedia/Poster.js
+++ b/docs/pages/CustomComponents/AlternativeMedia/Poster.js
@@ -1,4 +1,5 @@
 // @flow
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React from 'react'
 import { jsx } from '@emotion/react'

--- a/docs/pages/CustomComponents/AlternativeMedia/Progress.js
+++ b/docs/pages/CustomComponents/AlternativeMedia/Progress.js
@@ -1,4 +1,5 @@
 // @flow
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React from 'react'
 import { jsx } from '@emotion/react'

--- a/docs/pages/CustomComponents/AlternativeMedia/Progress.js
+++ b/docs/pages/CustomComponents/AlternativeMedia/Progress.js
@@ -1,7 +1,8 @@
 // @flow
-// @jsx glam
-import glam from 'glam'
+/** @jsx jsx */
 import React from 'react'
+import { jsx } from '@emotion/react'
+
 import { colors } from '../../../theme'
 
 type Props = { progress: number }

--- a/docs/pages/CustomComponents/AlternativeMedia/View.js
+++ b/docs/pages/CustomComponents/AlternativeMedia/View.js
@@ -1,7 +1,7 @@
 // @flow
-// @jsx glam
-import glam from 'glam'
+/** @jsx jsx */
 import React, { Component, type ElementRef } from 'react'
+import { jsx } from '@emotion/react'
 import rafScheduler from 'raf-schd'
 
 import Icon from './Icon'

--- a/docs/pages/CustomComponents/AlternativeMedia/View.js
+++ b/docs/pages/CustomComponents/AlternativeMedia/View.js
@@ -1,4 +1,5 @@
 // @flow
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React, { Component, type ElementRef } from 'react'
 import { jsx } from '@emotion/react'

--- a/docs/pages/CustomComponents/ImageViewer/components.js
+++ b/docs/pages/CustomComponents/ImageViewer/components.js
@@ -1,8 +1,8 @@
 // @flow
-// @jsx glam
-
-import glam from 'glam'
+/** @jsx jsx */
 import React from 'react'
+import { jsx } from '@emotion/react'
+
 import { colors } from '../../../theme'
 import { smallDevice, largeDevice } from '../../../utils'
 

--- a/docs/pages/CustomComponents/ImageViewer/components.js
+++ b/docs/pages/CustomComponents/ImageViewer/components.js
@@ -1,4 +1,5 @@
 // @flow
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React from 'react'
 import { jsx } from '@emotion/react'

--- a/docs/pages/CustomComponents/ImageViewer/index.js
+++ b/docs/pages/CustomComponents/ImageViewer/index.js
@@ -1,10 +1,9 @@
 // @flow
-// @jsx glam
-
-import glam from 'glam'
+/** @jsx jsx */
 import React, { Component } from 'react'
-import Carousel, { Modal, ModalGateway } from '../../../../src/components'
+import { jsx } from '@emotion/react'
 
+import Carousel, { Modal, ModalGateway } from '../../../../src/components'
 import { Heading } from '../../components'
 import { colors } from '../../../theme'
 import { largeDevice } from '../../../utils'

--- a/docs/pages/CustomComponents/ImageViewer/index.js
+++ b/docs/pages/CustomComponents/ImageViewer/index.js
@@ -1,4 +1,5 @@
 // @flow
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React, { Component } from 'react'
 import { jsx } from '@emotion/react'

--- a/docs/pages/CustomStyles/CarouselExample.js
+++ b/docs/pages/CustomStyles/CarouselExample.js
@@ -1,6 +1,4 @@
 // @flow
-// @jsx glam
-import glam from 'glam'
 import React, { Component } from 'react'
 
 import Carousel from '../../../src/components'

--- a/docs/pages/CustomStyles/ModalExample.js
+++ b/docs/pages/CustomStyles/ModalExample.js
@@ -1,6 +1,4 @@
 // @flow
-// @jsx glam
-import glam from 'glam'
 import React, { Component } from 'react'
 
 import Carousel, { Modal, ModalGateway } from '../../../src/components'

--- a/docs/pages/CustomStyles/index.js
+++ b/docs/pages/CustomStyles/index.js
@@ -1,6 +1,4 @@
 // @flow
-// @jsx glam
-import glam from 'glam'
 import React, { Component } from 'react'
 import { Helmet } from 'react-helmet'
 
@@ -50,8 +48,8 @@ export default class CustomStyles extends Component<Props> {
         <Title>Styles</Title>
         <p>
           React-Images offers a flexible, light-weight styling framework which is a thin abstraction over simple javascript objects using{' '}
-          <a href="https://github.com/threepointone/glam" target="_blank">
-            glam
+          <a href="https://emotion.sh/" target="_blank">
+            Emotion
           </a>
           .
         </p>

--- a/docs/pages/Home/GalleryExample.js
+++ b/docs/pages/Home/GalleryExample.js
@@ -1,7 +1,7 @@
 // @flow
-// @jsx glam
-import glam from 'glam'
+/** @jsx jsx */
 import React, { Component, Fragment } from 'react'
+import { jsx } from '@emotion/react'
 
 import { type ProviderProps } from '../../ImageProvider'
 import Carousel, { Modal, ModalGateway } from '../../../src/components'

--- a/docs/pages/Home/GalleryExample.js
+++ b/docs/pages/Home/GalleryExample.js
@@ -1,4 +1,5 @@
 // @flow
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React, { Component, Fragment } from 'react'
 import { jsx } from '@emotion/react'

--- a/docs/pages/Home/index.js
+++ b/docs/pages/Home/index.js
@@ -1,6 +1,4 @@
 // @flow
-// @jsx glam
-import glam from 'glam'
 import React, { Component } from 'react'
 
 import { type ProviderProps } from '../../ImageProvider'

--- a/docs/pages/Patterns/RouterGallery.js
+++ b/docs/pages/Patterns/RouterGallery.js
@@ -1,6 +1,4 @@
 // @flow
-// @jsx glam
-import glam from 'glam'
 import React, { Component } from 'react'
 
 import Carousel from '../../../src/components'

--- a/docs/pages/Patterns/index.js
+++ b/docs/pages/Patterns/index.js
@@ -1,6 +1,4 @@
 // @flow
-// @jsx glam
-import glam from 'glam'
 import React, { Component } from 'react'
 import { Helmet } from 'react-helmet'
 

--- a/docs/pages/Thanks/index.js
+++ b/docs/pages/Thanks/index.js
@@ -1,6 +1,4 @@
 // @flow
-// @jsx glam
-import glam from 'glam'
 import React, { Component } from 'react'
 
 import { Title } from '../components'

--- a/docs/pages/components.js
+++ b/docs/pages/components.js
@@ -51,7 +51,6 @@ export const Heading = ({ source, ...props }: { source: string }) => (
         href={headingLink(source)}
         target="_blank"
         css={{
-          color: colors.primary,
           borderBottom: '1px solid rgba(0, 215, 255, 0.25)',
           color: '#00d7ff',
           textDecoration: 'none',

--- a/docs/pages/components.js
+++ b/docs/pages/components.js
@@ -1,17 +1,15 @@
 // @flow
-// @jsx glam
-
-import glam from 'glam'
+/** @jsx jsx */
 import React, { type Node } from 'react'
-
+import { jsx } from '@emotion/react'
 import SyntaxHighlighter, { registerLanguage } from 'react-syntax-highlighter/prism-light'
-import jsx from 'react-syntax-highlighter/languages/prism/jsx'
+import { jsx as highlighterJsx } from 'react-syntax-highlighter/languages/prism'
 import { tomorrow } from 'react-syntax-highlighter/styles/prism'
 
 import { colors } from '../theme'
 import { smallDevice } from '../utils'
 
-registerLanguage('jsx', jsx)
+registerLanguage('jsx', highlighterJsx)
 
 // ==============================
 // Title

--- a/docs/pages/components.js
+++ b/docs/pages/components.js
@@ -1,4 +1,5 @@
 // @flow
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React, { type Node } from 'react'
 import { jsx } from '@emotion/react'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-images",
-  "version": "1.3.0",
+  "version": "1.2.0",
   "description": "A mobile-friendly, highly customizable, carousel component for displaying media in ReactJS",
   "main": "lib/index.js",
   "jsnext:main": "dist/react-images.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-images",
-  "version": "1.2.0-beta.7",
+  "version": "1.3.0",
   "description": "A mobile-friendly, highly customizable, carousel component for displaying media in ReactJS",
   "main": "lib/index.js",
   "jsnext:main": "dist/react-images.es.js",
@@ -35,6 +35,7 @@
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
     "copy-webpack-plugin": "^5.1.2",
+    "cross-env": "^7.0.3",
     "css-loader": "^3.6.0",
     "dotenv": "^8.2.0",
     "eslint": "^7.19.0",
@@ -66,9 +67,8 @@
     "webpack-dev-server": "^3.11.2"
   },
   "dependencies": {
+    "@emotion/react": "^11.10.4",
     "a11y-focus-store": "^1.0.0",
-    "cross-env": "^7.0.3",
-    "glam": "^5.0.1",
     "html-react-parser": "^1.2.4",
     "raf-schd": "^4.0.2",
     "react-focus-on": "^3.5.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@
 
 import babel from 'rollup-plugin-babel'
 import resolve from 'rollup-plugin-node-resolve'
+import commonjs from 'rollup-plugin-commonjs'
 import { uglify } from 'rollup-plugin-uglify'
 import replace from 'rollup-plugin-replace'
 import { minify } from 'uglify-es'
@@ -62,7 +63,12 @@ export default [
       globals: globals,
     },
     external: external,
-    plugins: [babel(babelOptions(false)), injectSecret(), resolve()],
+    plugins: [
+      babel(babelOptions(false)),
+      injectSecret(),
+      resolve(),
+      commonjs({ include: /node_modules\/hoist-non-react-statics/ })
+    ],
   },
   {
     input: 'src/index.umd.js',
@@ -73,6 +79,12 @@ export default [
       globals: globals,
     },
     external: external,
-    plugins: [babel(babelOptions(true)), injectSecret(), resolve(), uglify({}, minify)],
+    plugins: [
+      babel(babelOptions(true)),
+      injectSecret(),
+      resolve(),
+      commonjs({ include: /node_modules\/hoist-non-react-statics/ }),
+      uglify({}, minify)
+    ],
   },
 ]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,6 @@ const name = 'Images'
 const path = 'dist/react-images'
 const globals = {
   classnames: 'classNames',
-  glam: 'glam',
   'prop-types': 'PropTypes',
   'react-dom': 'ReactDOM',
   'react-input-autosize': 'AutosizeInput',

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -1,8 +1,6 @@
 // @flow
-// @jsx glam
 import React, { Component, type ElementRef } from 'react'
 import { findDOMNode } from 'react-dom'
-import glam from 'glam'
 import rafScheduler from 'raf-schd'
 import { ViewPager, Frame, Track, View as PageView } from 'react-view-pager'
 

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -1,7 +1,5 @@
 // @flow
-// @jsx glam
 import React, { type ElementRef, type Node } from 'react'
-import glam from 'glam'
 import { Div } from '../primitives'
 import { type PropsWithStyles } from '../types'
 import { className } from '../utils'

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,6 +1,4 @@
 // @flow
-// @jsx glam
-import glam from 'glam'
 import React from 'react'
 
 import { smallDevice } from './css-helpers'
@@ -36,6 +34,7 @@ export const footerCSS = ({ isModal, interactionIsIdle }: State) => ({
   padding: isModal ? '30px 20px 20px' : '10px 0',
   position: isModal ? 'absolute' : null,
   right: isModal ? 0 : null,
+  background: isModal ? 'linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0.33))' : null,
   transform: isModal ? `translateY(${interactionIsIdle ? 10 : 0}px)` : null,
   transition: 'opacity 300ms, transform 300ms',
   zIndex: isModal ? 1 : null,
@@ -54,8 +53,6 @@ const footerBaseClassName = componentBaseClassNames.Footer
 const Footer = (props: Props) => {
   const { components, getStyles, innerProps, isFullscreen, isModal } = props
 
-  const style = isModal ? { background: 'linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0.33))' } : null
-
   const state = { isFullscreen, isModal }
   const cn = {
     container: className(footerBaseClassName, state),
@@ -73,9 +70,6 @@ const Footer = (props: Props) => {
     <Div
       css={css.container}
       className={cn.container}
-      // TODO glam prefixer fails on gradients
-      // https://github.com/threepointone/glam/issues/35
-      style={style}
       {...innerProps}
     >
       <Caption {...props} />

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,7 +1,5 @@
 // @flow
-// @jsx glam
 import React, { type Node } from 'react'
-import glam from 'glam'
 
 import { Button, Div } from '../primitives'
 import { className } from '../utils'
@@ -29,6 +27,7 @@ export const headerCSS = ({ interactionIsIdle }: State) => ({
   padding: 10,
   paddingBottom: 20,
   position: 'absolute',
+  background: 'linear-gradient(rgba(0,0,0,0.33), rgba(0,0,0,0))',
   transform: `translateY(${interactionIsIdle ? -10 : 0}px)`,
   transition: 'opacity 300ms, transform 300ms',
   top: 0,
@@ -56,11 +55,6 @@ const Header = (props: Props) => {
     <Div
       css={getStyles(headerBaseClassName, props)}
       className={className(headerBaseClassName, state)}
-      // TODO glam prefixer fails on gradients
-      // https://github.com/threepointone/glam/issues/35
-      style={{
-        background: 'linear-gradient(rgba(0,0,0,0.33), rgba(0,0,0,0))',
-      }}
       {...innerProps}
     >
       <span />

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -1,7 +1,5 @@
 // @flow
-// @jsx glam
 import React, { cloneElement, Component } from 'react'
-import glam from 'glam'
 import { FullScreen } from 'react-full-screen'
 import focusStore from 'a11y-focus-store'
 import { defaultModalComponents, type ModalComponents } from '../defaultComponents'

--- a/src/components/Modal/styled.js
+++ b/src/components/Modal/styled.js
@@ -1,7 +1,7 @@
 // @flow
-// @jsx glam
+/** @jsx jsx */
 import React from 'react'
-import glam from 'glam'
+import { jsx } from '@emotion/react'
 import { Div } from '../../primitives'
 import { type PropsWithStyles } from '../../types'
 import { className } from '../../utils'

--- a/src/components/Modal/styled.js
+++ b/src/components/Modal/styled.js
@@ -1,4 +1,5 @@
 // @flow
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React from 'react'
 import { jsx } from '@emotion/react'

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -1,7 +1,5 @@
 // @flow
-// @jsx glam
 import React, { type Node } from 'react'
-import glam from 'glam'
 
 import { Button, Nav } from '../primitives'
 import { type PropsWithStyles } from '../types'

--- a/src/components/View.js
+++ b/src/components/View.js
@@ -1,7 +1,5 @@
 // @flow
-// @jsx glam
 import React from 'react'
-import glam from 'glam'
 
 import { Div, Img } from '../primitives'
 import { type PropsWithStyles } from '../types'

--- a/src/components/svg.js
+++ b/src/components/svg.js
@@ -1,7 +1,7 @@
 // @flow
-// @jsx glam
+/** @jsx jsx */
 import React from 'react'
-import glam from 'glam'
+import { jsx } from '@emotion/react'
 
 type Props = { size: number }
 

--- a/src/components/svg.js
+++ b/src/components/svg.js
@@ -1,4 +1,5 @@
 // @flow
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React from 'react'
 import { jsx } from '@emotion/react'

--- a/src/formatters.js
+++ b/src/formatters.js
@@ -67,7 +67,7 @@ function getAltText({ data, index }): string {
       console.warn(
         `Image ${
           index + 1
-        } has a non-string caption, but no alt value provided. This will probably make the alt prop unintelligible for screen readers. Is this intentional?`,
+        } has a non-string caption, but no alt value provided. This will probably make the alt prop unintelligible for screen readers. Is this intentional?`,
       )
     }
 

--- a/src/primitives.js
+++ b/src/primitives.js
@@ -1,7 +1,7 @@
 // @flow
-// @jsx glam
+/** @jsx jsx */
 import React from 'react'
-import glam from 'glam'
+import { jsx } from '@emotion/react'
 
 type Props = {
   css?: {},

--- a/src/primitives.js
+++ b/src/primitives.js
@@ -1,4 +1,5 @@
 // @flow
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React from 'react'
 import { jsx } from '@emotion/react'

--- a/src/styles.js
+++ b/src/styles.js
@@ -13,8 +13,6 @@ import { blanketCSS, dialogCSS, positionerCSS } from './components/Modal/styled'
 type Props = { [key: string]: any }
 type StyleDef = Props => Object
 
-export type GetStyles = (string, Props) => {}
-
 export type CarouselStyles = {
   container: StyleDef,
   footer: StyleDef,
@@ -53,25 +51,4 @@ export const defaultModalStyles: CarouselStyles = {
   blanket: blanketCSS,
   dialog: dialogCSS,
   positioner: positionerCSS,
-}
-
-// Merge Utility
-// Allows consumers to extend a base Carousel or Modal with additional styles
-
-export function mergeStyles(source: Object, target: Object = {}) {
-  // initialize with source styles
-  const styles = { ...source }
-
-  // massage in target styles
-  Object.keys(target).forEach(key => {
-    if (source[key]) {
-      styles[key] = (rsCss, props) => {
-        return target[key](source[key](rsCss, props), props)
-      }
-    } else {
-      styles[key] = target[key]
-    }
-  })
-
-  return styles
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,12 +35,34 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-module-imports@^7.16.7":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz#1e3ebdbbd08aad1437b428c50204db13c5a3ca6e"
+  integrity sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
+  dependencies:
+    "@babel/types" "^7.18.6"
+
+"@babel/helper-plugin-utils@^7.18.6":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.9.tgz#4b8aea3b069d8cb8a72cdfe28ddf5ceca695ef2f"
+  integrity sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==
+
 "@babel/helper-split-export-declaration@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz#31a9f30070f91368a7182cf05f831781065fc7a9"
   integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
   dependencies:
     "@babel/types" "^7.8.3"
+
+"@babel/helper-string-parser@^7.18.10":
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.18.10.tgz#181f22d28ebe1b3857fa575f5c290b1aaf659b56"
+  integrity sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==
+
+"@babel/helper-validator-identifier@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
+  integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
 
 "@babel/helper-validator-identifier@^7.9.0", "@babel/helper-validator-identifier@^7.9.5":
   version "7.9.5"
@@ -61,6 +83,13 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.6.tgz#3b1bbb30dabe600cd72db58720998376ff653bc7"
   integrity sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==
 
+"@babel/plugin-syntax-jsx@^7.17.12":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz#a8feef63b010150abd97f1649ec296e849943ca0"
+  integrity sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.6"
+
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2":
   version "7.9.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
@@ -72,6 +101,13 @@
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.13.tgz#0a21452352b02542db0ffb928ac2d3ca7cb6d66d"
   integrity sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
+  integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -99,6 +135,15 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
+"@babel/types@^7.18.6":
+  version "7.18.13"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.13.tgz#30aeb9e514f4100f7c1cb6e5ba472b30e48f519a"
+  integrity sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==
+  dependencies:
+    "@babel/helper-string-parser" "^7.18.10"
+    "@babel/helper-validator-identifier" "^7.18.6"
+    to-fast-properties "^2.0.0"
+
 "@babel/types@^7.7.0", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.5", "@babel/types@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.6.tgz#2c5502b427251e9de1bd2dff95add646d95cc9f7"
@@ -107,6 +152,95 @@
     "@babel/helper-validator-identifier" "^7.9.5"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
+
+"@emotion/babel-plugin@^11.10.0":
+  version "11.10.2"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.10.2.tgz#879db80ba622b3f6076917a1e6f648b1c7d008c7"
+  integrity sha512-xNQ57njWTFVfPAc3cjfuaPdsgLp5QOSuRsj9MA6ndEhH/AzuZM86qIQzt6rq+aGBwj3n5/TkLmU5lhAfdRmogA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.16.7"
+    "@babel/plugin-syntax-jsx" "^7.17.12"
+    "@babel/runtime" "^7.18.3"
+    "@emotion/hash" "^0.9.0"
+    "@emotion/memoize" "^0.8.0"
+    "@emotion/serialize" "^1.1.0"
+    babel-plugin-macros "^3.1.0"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^4.0.0"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+    stylis "4.0.13"
+
+"@emotion/cache@^11.10.0":
+  version "11.10.3"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.10.3.tgz#c4f67904fad10c945fea5165c3a5a0583c164b87"
+  integrity sha512-Psmp/7ovAa8appWh3g51goxu/z3iVms7JXOreq136D8Bbn6dYraPnmL6mdM8GThEx9vwSn92Fz+mGSjBzN8UPQ==
+  dependencies:
+    "@emotion/memoize" "^0.8.0"
+    "@emotion/sheet" "^1.2.0"
+    "@emotion/utils" "^1.2.0"
+    "@emotion/weak-memoize" "^0.3.0"
+    stylis "4.0.13"
+
+"@emotion/hash@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.0.tgz#c5153d50401ee3c027a57a177bc269b16d889cb7"
+  integrity sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==
+
+"@emotion/memoize@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.0.tgz#f580f9beb67176fa57aae70b08ed510e1b18980f"
+  integrity sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==
+
+"@emotion/react@^11.10.4":
+  version "11.10.4"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.10.4.tgz#9dc6bccbda5d70ff68fdb204746c0e8b13a79199"
+  integrity sha512-j0AkMpr6BL8gldJZ6XQsQ8DnS9TxEQu1R+OGmDZiWjBAJtCcbt0tS3I/YffoqHXxH6MjgI7KdMbYKw3MEiU9eA==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@emotion/babel-plugin" "^11.10.0"
+    "@emotion/cache" "^11.10.0"
+    "@emotion/serialize" "^1.1.0"
+    "@emotion/use-insertion-effect-with-fallbacks" "^1.0.0"
+    "@emotion/utils" "^1.2.0"
+    "@emotion/weak-memoize" "^0.3.0"
+    hoist-non-react-statics "^3.3.1"
+
+"@emotion/serialize@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.1.0.tgz#b1f97b1011b09346a40e9796c37a3397b4ea8ea8"
+  integrity sha512-F1ZZZW51T/fx+wKbVlwsfchr5q97iW8brAnXmsskz4d0hVB4O3M/SiA3SaeH06x02lSNzkkQv+n3AX3kCXKSFA==
+  dependencies:
+    "@emotion/hash" "^0.9.0"
+    "@emotion/memoize" "^0.8.0"
+    "@emotion/unitless" "^0.8.0"
+    "@emotion/utils" "^1.2.0"
+    csstype "^3.0.2"
+
+"@emotion/sheet@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.2.0.tgz#771b1987855839e214fc1741bde43089397f7be5"
+  integrity sha512-OiTkRgpxescko+M51tZsMq7Puu/KP55wMT8BgpcXVG2hqXc0Vo0mfymJ/Uj24Hp0i083ji/o0aLddh08UEjq8w==
+
+"@emotion/unitless@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.8.0.tgz#a4a36e9cbdc6903737cd20d38033241e1b8833db"
+  integrity sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw==
+
+"@emotion/use-insertion-effect-with-fallbacks@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz#ffadaec35dbb7885bd54de3fa267ab2f860294df"
+  integrity sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==
+
+"@emotion/utils@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.2.0.tgz#9716eaccbc6b5ded2ea5a90d65562609aab0f561"
+  integrity sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw==
+
+"@emotion/weak-memoize@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz#ea89004119dc42db2e1dba0f97d553f7372f6fcb"
+  integrity sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg==
 
 "@eslint/eslintrc@^0.3.0":
   version "0.3.0"
@@ -982,6 +1116,15 @@ babel-plugin-external-helpers@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-macros@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz#9ef6dc74deb934b4db344dc973ee851d148c50c1"
+  integrity sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    cosmiconfig "^7.0.0"
+    resolve "^1.19.0"
+
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
@@ -1521,11 +1664,6 @@ boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
-
-bowser@^1.7.3:
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.9.4.tgz#890c58a2813a9d3243704334fa81b96a5c150c9a"
-  integrity sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -2314,14 +2452,6 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-css-in-js-utils@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz#3b472b398787291b47cfe3e44fecfdd9e914ba99"
-  integrity sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==
-  dependencies:
-    hyphenate-style-name "^1.0.2"
-    isobject "^3.0.1"
-
 css-loader@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.6.0.tgz#2e4b2c7e6e2d27f8c8f28f61bffcd2e6c91ef645"
@@ -2867,6 +2997,11 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
 escodegen@1.8.x:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.8.1.tgz#5a5b53af4693110bebb0867aa3430dd3b70a1018"
@@ -3258,7 +3393,7 @@ faye-websocket@^0.11.3:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fbjs@^0.8.16, fbjs@^0.8.9:
+fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -3385,6 +3520,11 @@ find-cache-dir@^2.1.0:
     commondir "^1.0.1"
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
+
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -3629,14 +3769,6 @@ gh-pages@^2.2.0:
     filenamify-url "^1.0.0"
     fs-extra "^8.1.0"
     globby "^6.1.0"
-
-glam@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/glam/-/glam-5.0.1.tgz#b965a46f1a7f9ba3a23d16430b2e706f63c80ee8"
-  integrity sha512-NCnYcPpefXJMH30LaUfKKP3BkpipI9jkeOvzMZAd76cuDxfKmQRBvgQ1LxXRj9IRZVAwl0K3WQvbw+tiyK2pcw==
-  dependencies:
-    fbjs "^0.8.16"
-    inline-style-prefixer "^3.0.8"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -3951,7 +4083,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.1.0:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -4144,11 +4276,6 @@ humanize-url@^1.0.0:
     normalize-url "^1.0.0"
     strip-url-auth "^1.0.0"
 
-hyphenate-style-name@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz#097bb7fa0b8f1a9cf0bd5c734cf95899981a9b48"
-  integrity sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ==
-
 iconv-lite@0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -4266,14 +4393,6 @@ inline-style-parser@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.1.1.tgz#ec8a3b429274e9c0a1f1c4ffa9453a7fef72cea1"
   integrity sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==
-
-inline-style-prefixer@^3.0.8:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz#8551b8e5b4d573244e66a34b04f7d32076a2b534"
-  integrity sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=
-  dependencies:
-    bowser "^1.7.3"
-    css-in-js-utils "^2.0.0"
 
 internal-ip@^4.3.0:
   version "4.3.0"
@@ -4394,6 +4513,13 @@ is-core-module@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
   integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.9.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.10.0.tgz#9012ede0a91c69587e647514e1d5277019e728ed"
+  integrity sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==
   dependencies:
     has "^1.0.3"
 
@@ -6009,6 +6135,11 @@ path-parse@^1.0.6:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
+path-parse@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
@@ -6951,6 +7082,15 @@ resolve@^1.18.1:
     is-core-module "^2.1.0"
     path-parse "^1.0.6"
 
+resolve@^1.19.0:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
+  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
+  dependencies:
+    is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
 restore-cursor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
@@ -7791,6 +7931,11 @@ style-to-object@0.3.0:
   dependencies:
     inline-style-parser "0.1.1"
 
+stylis@4.0.13:
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.13.tgz#f5db332e376d13cc84ecfe5dace9a2a51d954c91"
+  integrity sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag==
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -7823,6 +7968,11 @@ supports-color@^7.1.0:
   integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
   dependencies:
     has-flag "^4.0.0"
+
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 tabbable@1.1.2:
   version "1.1.2"


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

**Description of changes:**

Port `react-images` from the unsupported `glam` css-in-js library to `emotion`

**Related issues (if any):**

**Checks:**

- [x] Please confirm `yarn run lint` ran successfully
- [x] Please confirm that only `/src` and `/examples/src` are committed
- - Needed to update `/docs` too!
